### PR TITLE
Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,8 @@ erl_crash.dump
 /.idea
 alembic.iml
 
+# mix docs output
+/doc
+
 # mix test --cover output
 /cover

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,8 @@ alembic.iml
 # mix docs output
 /doc
 
+# mix inch output
+/docs
+
 # mix test --cover output
 /cover

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Alembic
 
 [![CircleCI](https://circleci.com/gh/C-S-D/alembic.svg?style=svg)](https://circleci.com/gh/C-S-D/alembic)
+[![Inline docs](http://inch-ci.org/github/C-S-D/alembic.svg)](http://inch-ci.org/github/C-S-D/alembic)
+
 
 **TODO: Add description**
 

--- a/circle.yml
+++ b/circle.yml
@@ -19,6 +19,7 @@ test:
   override:
     - mix test --cover
   post:
+    - mix inch.report
     - cp -a cover ${CIRCLE_ARTIFACTS}/
     - mkdir -p ${CIRCLE_TEST_REPORTS}/Elixir
     - mv _build/test/test-junit-report.xml ${CIRCLE_TEST_REPORTS}/Elixir/

--- a/lib/alembic.ex
+++ b/lib/alembic.ex
@@ -1,2 +1,5 @@
 defmodule Alembic do
+  @moduledoc """
+  [JSONAPI 1.0](http://jsonapi.org/format/1.0/)
+  """
 end

--- a/mix.exs
+++ b/mix.exs
@@ -39,6 +39,8 @@ defmodule Alembic.Mixfile do
       {:earmark, "~> 0.2.1", only: :dev},
       # documentation generation
       {:ex_doc, "~> 0.11.5", only: :dev},
+      # documentation coverage
+      {:inch_ex, "~> 0.5.1", only: [:dev, :test]},
       # formats test output for CircleCI
       {:junit_formatter, "~> 1.0", only: :test}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -2,13 +2,17 @@ defmodule Alembic.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :alembic,
-     version: "0.0.1",
-     elixir: "~> 1.2",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps,
-     test_coverage: [tool: Coverex.Task]]
+    [
+      app: :alembic,
+      build_embedded: Mix.env == :prod,
+      deps: deps,
+      elixir: "~> 1.2",
+      name: "Alembic",
+      source_url: "https://github.com/C-S-D/alembic",
+      start_permanent: Mix.env == :prod,
+      test_coverage: [tool: Coverex.Task],
+      version: "0.0.1"
+    ]
   end
 
   # Configuration for the OTP application
@@ -31,8 +35,12 @@ defmodule Alembic.Mixfile do
     [
       # test coverge tool.  Allow `--cover` option for `mix test`
       {:coverex, "~> 1.4", only: :test},
+      # markdown to HTML converter for ex_doc
+      {:earmark, "~> 0.2.1", only: :dev},
+      # documentation generation
+      {:ex_doc, "~> 0.11.5", only: :dev},
       # formats test output for CircleCI
-      {:junit_formatter, "~> 1.0", only: :test},
+      {:junit_formatter, "~> 1.0", only: :test}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -5,6 +5,7 @@
   "hackney": {:hex, :hackney, "1.6.0", "8d1e9440c9edf23bf5e5e2fe0c71de03eb265103b72901337394c840eec679ac", [:rebar3], [{:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:certifi, "0.4.0", [hex: :certifi, optional: false]}]},
   "httpoison": {:hex, :httpoison, "0.8.3", "b675a3fdc839a0b8d7a285c6b3747d6d596ae70b6ccb762233a990d7289ccae4", [:mix], [{:hackney, "~> 1.6.0", [hex: :hackney, optional: false]}]},
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
+  "inch_ex": {:hex, :inch_ex, "0.5.1", "c1c18966c935944cbb2d273796b36e44fab3c54fd59f906ff026a686205b4e14", [:mix], [{:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},
   "junit_formatter": {:hex, :junit_formatter, "1.0.1", "692220f70d227bfa29593a87c0058e0636aa47d256981d6902acc7e0704037fa", [:mix], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,7 @@
 %{"certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
   "coverex": {:hex, :coverex, "1.4.9", "5f923d9fa5d50cf0eea40a55940cfc7dbf73138fb4dbab565c54d7f2e8724722", [:mix], [{:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}, {:httpoison, "~> 0.8", [hex: :httpoison, optional: false]}]},
+  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
   "hackney": {:hex, :hackney, "1.6.0", "8d1e9440c9edf23bf5e5e2fe0c71de03eb265103b72901337394c840eec679ac", [:rebar3], [{:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:certifi, "0.4.0", [hex: :certifi, optional: false]}]},
   "httpoison": {:hex, :httpoison, "0.8.3", "b675a3fdc839a0b8d7a285c6b3747d6d596ae70b6ccb762233a990d7289ccae4", [:mix], [{:hackney, "~> 1.6.0", [hex: :hackney, optional: false]}]},
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},


### PR DESCRIPTION
# Changelog
## Enhancements
* Use `ex_doc` and `earmark` to generate documentation with `mix docs`
* Use `mix inch (--pedantic)` to see coverage for documentation