### PR TITLE
Credo

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,6 +19,7 @@ test:
   override:
     - mix test --cover
   post:
+    - mix credo --strict
     - mix inch.report
     - cp -a cover ${CIRCLE_ARTIFACTS}/
     - mkdir -p ${CIRCLE_TEST_REPORTS}/Elixir

--- a/config/.credo.exs
+++ b/config/.credo.exs
@@ -1,0 +1,68 @@
+%{
+  configs: [
+    %{
+      name: "default",
+      checks: [
+        {Credo.Check.Consistency.ExceptionNames},
+        {Credo.Check.Consistency.LineEndings},
+        {Credo.Check.Consistency.SpaceAroundOperators},
+        {Credo.Check.Consistency.SpaceInParentheses},
+        {Credo.Check.Consistency.TabsOrSpaces},
+
+        # For some checks, like AliasUsage, you can only customize the priority
+        # Priority values are: `low, normal, high, higher`
+        {Credo.Check.Design.AliasUsage, priority: :low},
+        # For others you can set parameters
+        {Credo.Check.Design.DuplicatedCode, mass_threshold: 16, nodes_threshold: 2},
+
+        # You can also customize the exit_status of each check.
+        # If you don't want TODO comments to cause `mix credo` to fail, just
+        # set this value to 0 (zero).
+        {Credo.Check.Design.TagTODO, exit_status: 2},
+        {Credo.Check.Design.TagFIXME},
+
+        {Credo.Check.Readability.FunctionNames},
+        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 80},
+        {Credo.Check.Readability.ModuleAttributeNames},
+        {Credo.Check.Readability.ModuleDoc},
+        {Credo.Check.Readability.ModuleNames},
+        {Credo.Check.Readability.PredicateFunctionNames},
+        {Credo.Check.Readability.TrailingBlankLine},
+        {Credo.Check.Readability.TrailingWhiteSpace},
+        {Credo.Check.Readability.VariableNames},
+
+        {Credo.Check.Refactor.ABCSize},
+        {Credo.Check.Refactor.CaseTrivialMatches},
+        {Credo.Check.Refactor.CondStatements},
+        {Credo.Check.Refactor.FunctionArity},
+        {Credo.Check.Refactor.MatchInCondition},
+        {Credo.Check.Refactor.PipeChainStart},
+        {Credo.Check.Refactor.CyclomaticComplexity},
+        {Credo.Check.Refactor.NegatedConditionsInUnless},
+        {Credo.Check.Refactor.NegatedConditionsWithElse},
+        {Credo.Check.Refactor.Nesting},
+        {Credo.Check.Refactor.UnlessWithElse},
+
+        {Credo.Check.Warning.IExPry},
+        {Credo.Check.Warning.IoInspect},
+        {Credo.Check.Warning.NameRedeclarationByAssignment},
+        {Credo.Check.Warning.NameRedeclarationByCase},
+        {Credo.Check.Warning.NameRedeclarationByDef},
+        {Credo.Check.Warning.NameRedeclarationByFn},
+        {Credo.Check.Warning.OperationOnSameValues},
+        {Credo.Check.Warning.UnusedEnumOperation},
+        {Credo.Check.Warning.UnusedKeywordOperation},
+        {Credo.Check.Warning.UnusedListOperation},
+        {Credo.Check.Warning.UnusedStringOperation},
+        {Credo.Check.Warning.UnusedTupleOperation},
+        {Credo.Check.Warning.OperationWithConstantResult},
+      ],
+      files: %{
+        excluded: [],
+        # add "test/" so tests don't get too gnarly and to remain consistent with ruby projects that run rubocop on
+        # "spec/"
+        included: ["lib/", "test/"]
+      }
+    }
+  ]
+}

--- a/mix.exs
+++ b/mix.exs
@@ -33,6 +33,8 @@ defmodule Alembic.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
+      # static code analysis for style and consistency
+      {:credo, "~> 0.3.13", only: [:dev, :test]},
       # test coverge tool.  Allow `--cover` option for `mix test`
       {:coverex, "~> 1.4", only: :test},
       # markdown to HTML converter for ex_doc

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,7 @@
-%{"certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
+%{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
+  "certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
   "coverex": {:hex, :coverex, "1.4.9", "5f923d9fa5d50cf0eea40a55940cfc7dbf73138fb4dbab565c54d7f2e8724722", [:mix], [{:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}, {:httpoison, "~> 0.8", [hex: :httpoison, optional: false]}]},
+  "credo": {:hex, :credo, "0.3.13", "90d2d2deb9d376bb2a63f81126a320c3920ce65acb1294982ab49a8aacc7d89f", [:mix], [{:bunt, "~> 0.1.4", [hex: :bunt, optional: false]}]},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
   "hackney": {:hex, :hackney, "1.6.0", "8d1e9440c9edf23bf5e5e2fe0c71de03eb265103b72901337394c840eec679ac", [:rebar3], [{:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:certifi, "0.4.0", [hex: :certifi, optional: false]}]},

--- a/test/alembic_test.exs
+++ b/test/alembic_test.exs
@@ -1,4 +1,8 @@
 defmodule AlembicTest do
+  @moduledoc """
+  Tests `Alembic`
+  """
+
   use ExUnit.Case
   doctest Alembic
 


### PR DESCRIPTION
# Changelog
## Enhancements
* Configura `mix credo` to run against `lib` and `test` to maintain consistency with Ruby projects that use rubocop on `lib` and `spec`.
* Run `mix credo --strict` on CircleCI to check style and consistency in CI
