### PR TITLE
Validation and conversion of JSON API errors Documents

### DIFF
--- a/config/.credo.exs
+++ b/config/.credo.exs
@@ -22,7 +22,7 @@
         {Credo.Check.Design.TagFIXME},
 
         {Credo.Check.Readability.FunctionNames},
-        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 80},
+        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 120},
         {Credo.Check.Readability.ModuleAttributeNames},
         {Credo.Check.Readability.ModuleDoc},
         {Credo.Check.Readability.ModuleNames},

--- a/lib/alembic.ex
+++ b/lib/alembic.ex
@@ -2,4 +2,14 @@ defmodule Alembic do
   @moduledoc """
   [JSONAPI 1.0](http://jsonapi.org/format/1.0/)
   """
+
+  @typedoc """
+  A JSON object
+  """
+  @type json_object :: %{String.t => json}
+
+  @typedoc """
+  Parsed JSON from `Poison.decode!` or some other decoder.
+  """
+  @type json :: nil | true | false | list | float | integer | String.t | json_object
 end

--- a/lib/alembic.ex
+++ b/lib/alembic.ex
@@ -12,4 +12,9 @@ defmodule Alembic do
   Parsed JSON from `Poison.decode!` or some other decoder.
   """
   @type json :: nil | true | false | list | float | integer | String.t | json_object
+
+  @typedoc """
+  A JSON Pointer as defined in [RFC6901](https://tools.ietf.org/html/rfc6901)
+  """
+  @type json_pointer :: String.t
 end

--- a/lib/alembic/document.ex
+++ b/lib/alembic/document.ex
@@ -1,0 +1,22 @@
+defmodule Alembic.Document do
+  @moduledoc """
+  JSON API refers to the top-level JSON structure as a [document](http://jsonapi.org/format/#document-structure).
+  """
+
+  alias Alembic.Error
+
+  defstruct errors: nil
+
+  # Types
+
+  @typedoc """
+  A JSON API [Document](http://jsonapi.org/format/#document-structure).
+
+  ## Errors
+
+  When an error occurs, only `errors` are returned in the document.
+  """
+  @type t :: %__MODULE__{
+               errors: [Error.t],
+             }
+end

--- a/lib/alembic/document.ex
+++ b/lib/alembic/document.ex
@@ -4,6 +4,13 @@ defmodule Alembic.Document do
   """
 
   alias Alembic.Error
+  alias Alembic.FromJson
+
+  # Behaviours
+
+  @behaviour FromJson
+
+  # Struct
 
   defstruct errors: nil
 
@@ -19,4 +26,233 @@ defmodule Alembic.Document do
   @type t :: %__MODULE__{
                errors: [Error.t],
              }
+
+  # Functions
+
+  @doc """
+  Converts a JSON object into a JSON API Document, `t`.
+
+  ## Error documents
+
+  Errors from the sender must have an `"errors"` key set to a list of errors.
+
+      iex> Alembic.Document.from_json(
+      ...>   %{
+      ...>     "errors" => [
+      ...>       %{
+      ...>         "code" => "1",
+      ...>         "detail" => "There was an error in data",
+      ...>         "id" => "2",
+      ...>         "links" => %{
+      ...>           "about" => %{
+      ...>             "href" => "/errors/2",
+      ...>             "meta" => %{
+      ...>               "extra" => "about meta"
+      ...>             }
+      ...>           }
+      ...>         },
+      ...>         "meta" => %{
+      ...>           "extra" => "error meta"
+      ...>         },
+      ...>         "source" => %{
+      ...>           "pointer" => "/data"
+      ...>         },
+      ...>         "status" => "422",
+      ...>         "title" => "There was an error"
+      ...>       }
+      ...>     ]
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :server
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: ""
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              code: "1",
+              detail: "There was an error in data",
+              id: "2",
+              links: %{
+                "about" => %Alembic.Link{
+                  href: "/errors/2",
+                  meta: %{
+                    "extra" => "about meta"
+                  }
+                }
+              },
+              meta: %{
+                "extra" => "error meta"
+              },
+              source: %Alembic.Source{
+                pointer: "/data"
+              },
+              status: "422",
+              title: "There was an error"
+            }
+          ]
+        }
+      }
+
+  Error objects **MUST** be returned as an *array* keyed by `"errors"` in the top level of a JSON API document.
+
+      iex> Alembic.Document.from_json(
+      ...>   %{"errors" => "Lots of errors"},
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :server
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: ""
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/errors` type is not array",
+              meta: %{
+                "type" => "array"
+              },
+              source: %Alembic.Source{
+                pointer: "/errors"
+              },
+              status: "422",
+              title: "Type is wrong"
+            }
+          ]
+        }
+      }
+
+  If `"errors"` isn't even present, it will be a different error.
+
+      iex> Alembic.Document.from_json(
+      ...>   %{},
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :server
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: ""
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/errors` is missing",
+              meta: %{
+                "child" => "errors"
+              },
+              source: %Alembic.Source{
+                pointer: ""
+              },
+              status: "422",
+              title: "Child missing"
+            }
+          ]
+        }
+      }
+
+  """
+  def from_json(json, error_template)
+
+  def from_json(%{"errors" => errors}, error_template = %Error{}) do
+    field_result = errors
+                   |> FromJson.from_json_array(Error.descend(error_template, "errors"), Error)
+                   |> FromJson.put_key(:errors)
+
+    FromJson.merge({:ok, %__MODULE__{}}, field_result)
+  end
+
+  def from_json(%{}, error_template = %Error{}) do
+    {
+      :error,
+      %__MODULE__{
+        errors: [
+          Error.missing(error_template, "errors")
+        ]
+      }
+    }
+  end
+
+  @doc """
+  Merges the errors from two documents together.
+
+  The errors from the second document are prepended to the errors of the first document so that the errors as a whole
+  can be reversed with `reverse/1`
+  """
+  def merge(first, second)
+
+  @spec merge(%__MODULE__{errors: [Error.t]}, %__MODULE__{errors: [Error.t]}) :: %__MODULE__{errors: [Error.t]}
+  def merge(%__MODULE__{errors: first_errors}, %__MODULE__{errors: second_errors})
+      when is_list(first_errors) and is_list(second_errors) do
+    %__MODULE__{
+      # Don't use Enum.into as it will reverse the list immediately, which is more reversing that necessary since
+      # merge is called a bunch of time in sequence.
+      errors: Enum.reduce(second_errors, first_errors, fn (second_error, acc_errors) ->
+        [second_error | acc_errors]
+      end)
+    }
+  end
+
+  @doc """
+  Since `merge/2` adds the second `errors` to the beginning of a `first` document's `errors` list, the final merged
+  `errors` needs to be reversed to maintain the original order.
+
+      iex> merged = %Alembic.Document{
+      ...>   errors: [
+      ...>     %Alembic.Error{
+      ...>       detail: "The index `2` of `/data` is not a resource",
+      ...>       source: %Alembic.Source{
+      ...>         pointer: "/data/2"
+      ...>       },
+      ...>       title: "Element is not a resource"
+      ...>     },
+      ...>     %Alembic.Error{
+      ...>       detail: "The index `1` of `/data` is not a resource",
+      ...>       source: %Alembic.Source{
+      ...>         pointer: "/data/1"
+      ...>       },
+      ...>       title: "Element is not a resource"
+      ...>     }
+      ...>   ]
+      ...> }
+      iex> Alembic.Document.reverse(merged)
+      %Alembic.Document{
+        errors: [
+          %Alembic.Error{
+            detail: "The index `1` of `/data` is not a resource",
+            source: %Alembic.Source{
+              pointer: "/data/1"
+            },
+            title: "Element is not a resource"
+          },
+          %Alembic.Error{
+            detail: "The index `2` of `/data` is not a resource",
+            source: %Alembic.Source{
+              pointer: "/data/2"
+            },
+            title: "Element is not a resource"
+          }
+        ]
+      }
+
+  """
+  def reverse(document = %__MODULE__{errors: errors}) when is_list(errors) do
+    %__MODULE__{document | errors: Enum.reverse(errors)}
+  end
 end

--- a/lib/alembic/error.ex
+++ b/lib/alembic/error.ex
@@ -5,9 +5,93 @@ defmodule Alembic.Error do
   JSON API document.
   """
 
+  alias Alembic.FromJson
   alias Alembic.Links
   alias Alembic.Meta
   alias Alembic.Source
+
+  # Behaviours
+
+  @behaviour FromJson
+
+  # Constants
+
+  @code_options %{
+                  field: :code,
+                  member: %{
+                    from_json: &FromJson.string_from_json/2,
+                    name: "code"
+                  },
+                }
+
+  @detail_options %{
+                    field: :detail,
+                    member: %{
+                      from_json: &FromJson.string_from_json/2,
+                      name: "detail"
+                    },
+                  }
+
+  @id_options %{
+                field: :id,
+                member: %{
+                  from_json: &FromJson.string_from_json/2,
+                  name: "id"
+                }
+              }
+
+  @links_options %{
+                   field: :links,
+                   member: %{
+                     module: Links,
+                     name: "links"
+                   }
+                 }
+
+  @meta_options %{
+                  field: :meta,
+                  member: %{
+                    module: Meta,
+                    name: "meta"
+                  }
+                }
+
+  @source_options %{
+                    field: :source,
+                    member: %{
+                      module: Source,
+                      name: "source"
+                    }
+                  }
+
+  @status_options %{
+                    field: :status,
+                    member: %{
+                      from_json: &FromJson.string_from_json/2,
+                      name: "status"
+                    }
+                  }
+
+  @title_options %{
+                   field: :title,
+                   member: %{
+                     from_json: &FromJson.string_from_json/2,
+                     name: "title"
+                   }
+                 }
+
+  @child_options_list [
+    @code_options,
+    @detail_options,
+    @id_options,
+    @links_options,
+    @meta_options,
+    @source_options,
+    @status_options,
+    @title_options
+  ]
+
+  # Struct
 
   defstruct code: nil,
             detail: nil,
@@ -19,6 +103,11 @@ defmodule Alembic.Error do
             title: nil
 
   # Types
+
+  @typedoc """
+  The name of a JSON type in human-readable terms, such as `"array"` or `"object"`.
+  """
+  @type human_type :: String.t
 
   @typedoc """
   Additional information about problems encountered while performing an operation.
@@ -46,4 +135,289 @@ defmodule Alembic.Error do
                status: String.t,
                title: String.t
              }
+
+  @doc """
+  Descends `source` `pointer` to `child` of current `source` `pointer`
+
+      iex> Alembic.Error.descend(
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   },
+      ...>   1
+      ...> )
+      %Alembic.Error{
+        source: %Alembic.Source{
+          pointer: "/data/1"
+        }
+      }
+
+  """
+  @spec descend(t, String.t | integer) :: t
+  def descend(error = %__MODULE__{source: source}, child) do
+    %__MODULE__{error | source: Source.descend(source, child)}
+  end
+
+  @doc """
+  Converts a JSON object into a JSON API Error, `t`.
+
+      iex> Alembic.Error.from_json(
+      ...>   %{
+      ...>     "code" => "1",
+      ...>     "detail" => "There was an error in data",
+      ...>     "id" => "2",
+      ...>     "links" => %{
+      ...>       "about" => %{
+      ...>         "href" => "/errors/2",
+      ...>         "meta" => %{
+      ...>           "extra" => "about meta"
+      ...>         }
+      ...>       }
+      ...>     },
+      ...>     "meta" => %{
+      ...>       "extra" => "error meta"
+      ...>     },
+      ...>     "source" => %{
+      ...>       "pointer" => "/data"
+      ...>     },
+      ...>     "status" => "422",
+      ...>     "title" => "There was an error"
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/errors/0"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Alembic.Error{
+          code: "1",
+          detail: "There was an error in data",
+          id: "2",
+          links: %{
+            "about" => %Alembic.Link{
+              href: "/errors/2",
+              meta: %{
+                "extra" => "about meta"
+              }
+            }
+          },
+          meta: %{
+            "extra" => "error meta"
+          },
+          source: %Alembic.Source{
+            pointer: "/data"
+          },
+          status: "422",
+          title: "There was an error"
+        }
+      }
+
+  """
+  def from_json(json_object = %{}, template = %__MODULE__{}) do
+    parent = %{json: json_object, error_template: template}
+
+    @child_options_list
+    |> Stream.map(&Map.put(&1, :parent, parent))
+    |> Stream.map(&FromJson.from_parent_json_to_field_result/1)
+    |> FromJson.reduce({:ok, %__MODULE__{}})
+  end
+
+  @doc """
+  When two or more members can't be present at the same time.
+
+      iex> Alembic.Error.conflicting(
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/errors/0/source"
+      ...>     }
+      ...>   },
+      ...>   ~w{parameter pointer}
+      ...> )
+      %Alembic.Error{
+        detail: "The following members conflict with each other (only one can be present):\\nparameter\\npointer",
+        meta: %{
+          "children" => [
+            "parameter",
+            "pointer"
+          ]
+        },
+        source: %Alembic.Source{
+          pointer: "/errors/0/source"
+        },
+        status: "422",
+        title: "Children conflicting"
+      }
+
+  """
+  @spec conflicting(t, [String.t]) :: t
+  def conflicting(template, children)
+
+  def conflicting(%__MODULE__{source: source}, children) when is_list(children) do
+    %__MODULE__{
+      detail: "The following members conflict with each other (only one can be present):\n" <>
+              Enum.join(children, "\n"),
+      meta: %{
+        "children" => children
+      },
+      source: source,
+      status: "422",
+      title: "Children conflicting"
+    }
+  end
+
+  @doc """
+  When a required (**MUST** in the spec) member is missing
+
+  # Top-level member is missing
+
+      iex> Alembic.Error.missing(
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: ""
+      ...>     }
+      ...>   },
+      ...>   "data"
+      ...> )
+      %Alembic.Error{
+        detail: "`/data` is missing",
+        meta: %{
+          "child" => "data"
+        },
+        source: %Alembic.Source{
+          pointer: ""
+        },
+        status: "422",
+        title: "Child missing"
+      }
+
+  # Nested member is missing
+
+      iex> Alembic.Error.missing(
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   },
+      ...>   "type"
+      ...> )
+      %Alembic.Error{
+        detail: "`/data/type` is missing",
+        meta: %{
+          "child" => "type"
+        },
+        source: %Alembic.Source{
+          pointer: "/data"
+        },
+        status: "422",
+        title: "Child missing"
+      }
+
+  """
+  @spec missing(t, String.t) :: t
+  def missing(template, child)
+
+  def missing(%__MODULE__{source: source = %Source{pointer: parent_pointer}}, child) do
+    %__MODULE__{
+      detail: "`#{parent_pointer}/#{child}` is missing",
+      meta: %{
+        "child" => child
+      },
+      source: source,
+      status: "422",
+      title: "Child missing"
+    }
+  end
+
+  @doc """
+  Error when the JSON type of the field is wrong.
+
+  **NOTE: The *JSON* type should be used, not the Elixir/Erlang type, so if a member is not a `map` in Elixir, the
+  `human_type` should be `"object"`.  Likewise, if a member is not a `list` in Elixir, the `human_type` should be
+  `"array"`.**
+
+  # When member is not an Elixir `list` or JSON array
+
+      iex> validate_errors = fn
+      ...>   (list) when is_list(list) ->
+      ...>     {:ok, list}
+      ...>   (_) ->
+      ...>     {
+      ...>       :error,
+      ...>       Alembic.Error.type(
+      ...>         %Alembic.Error{
+      ...>           source: %Alembic.Source{
+      ...>             pointer: "/errors"
+      ...>           }
+      ...>         },
+      ...>         "array"
+      ...>       )
+      ...>     }
+      ...> end
+      iex> json = %{"errors" => "invalid"}
+      iex> validate_errors.(json["errors"])
+      {
+        :error,
+        %Alembic.Error{
+          detail: "`/errors` type is not array",
+          meta: %{
+            "type" => "array"
+          },
+          source: %Alembic.Source{
+            pointer: "/errors"
+          },
+          status: "422",
+          title: "Type is wrong"
+        }
+      }
+
+  # When member is not an Elixir `map` or JSON object
+
+      iex> validate_meta = fn
+      ...>   (meta) when is_map(meta) ->
+      ...>     {:ok, meta}
+      ...>   (_) ->
+      ...>     {
+      ...>       :error,
+      ...>       Alembic.Error.type(
+      ...>         %Alembic.Error{
+      ...>           source: %Alembic.Source{
+      ...>             pointer: "/meta"
+      ...>           }
+      ...>         },
+      ...>         "object"
+      ...>       )
+      ...>     }
+      ...> end
+      iex> json = %{"meta" => "invalid"}
+      iex> validate_meta.(json["meta"])
+      {
+        :error,
+        %Alembic.Error{
+          detail: "`/meta` type is not object",
+          meta: %{
+            "type" => "object"
+          },
+          source: %Alembic.Source{
+            pointer: "/meta"
+          },
+          status: "422",
+          title: "Type is wrong"
+        }
+      }
+  """
+  @spec type(t, human_type) :: t
+  def type(%__MODULE__{source: source = %Source{pointer: pointer}}, human_type) do
+    %__MODULE__{
+      detail: "`#{pointer}` type is not #{human_type}",
+      meta: %{
+        "type" => human_type
+      },
+      source: source,
+      status: "422",
+      title: "Type is wrong"
+    }
+  end
 end

--- a/lib/alembic/error.ex
+++ b/lib/alembic/error.ex
@@ -420,4 +420,105 @@ defmodule Alembic.Error do
       title: "Type is wrong"
     }
   end
+
+  defimpl Poison.Encoder do
+    @doc """
+    Encoded `Alembic.Error.t` as a `String.t` contain a JSON objecct where the `nil` fields from `Alembic.Error.t`
+    **DO NOT** appear.
+
+    An error can have only a code
+
+        iex> Poison.encode(
+        ...>   %Alembic.Error{
+        ...>     code: "123"
+        ...>   }
+        ...> )
+        {:ok, "{\\"code\\":\\"123\\"}"}
+
+    An error can have only a detail
+
+        iex> Poison.encode(
+        ...>   %Alembic.Error{
+        ...>     detail: "`/data` type is not object"
+        ...>   }
+        ...> )
+        {:ok, "{\\"detail\\":\\"`/data` type is not object\\"}"}
+
+    An error can have only an id
+
+        iex> Poison.encode(
+        ...>   %Alembic.Error{
+        ...>     id: "1"
+        ...>   }
+        ...> )
+        {:ok, "{\\"id\\":\\"1\\"}"}
+
+    An error can have only links
+
+        iex> Poison.encode(
+        ...>   %Alembic.Error{
+        ...>     links: %{
+        ...>       "object" => %Alembic.Link{
+        ...>         href: "http://example.com",
+        ...>         meta: %{
+        ...>           "extra" => "link object"
+        ...>         }
+        ...>       },
+        ...>       "url" => "http://example.com"
+        ...>     }
+        ...>   }
+        ...> )
+        {
+          :ok,
+          "{\\"links\\":{\\"url\\":\\"http://example.com\\",\\"object\\":{\\"meta\\":{\\"extra\\":" <>
+          "\\"link object\\"},\\"href\\":\\"http://example.com\\"}}}"
+        }
+
+    An error can have only meta
+
+        iex> Poison.encode(
+        ...>   %Alembic.Error{
+        ...>     meta: %{
+        ...>       "extra" => "stuff"
+        ...>     }
+        ...>   }
+        ...> )
+        {:ok, "{\\"meta\\":{\\"extra\\":\\"stuff\\"}}"}
+
+    An error can have only a source
+
+        iex> Poison.encode(
+        ...>   %Alembic.Error{
+        ...>     source: %Alembic.Source{
+        ...>       pointer: "/data"
+        ...>     }
+        ...>   }
+        ...> )
+        {:ok, "{\\"source\\":{\\"pointer\\":\\"/data\\"}}"}
+
+    An error can have only status
+
+        iex> Poison.encode(
+        ...>   %Alembic.Error{
+        ...>     status: "422"
+        ...>   }
+        ...> )
+        {:ok, "{\\"status\\":\\"422\\"}"}
+
+    An error can have only title
+
+        iex> Poison.encode(
+        ...>   %Alembic.Error{
+        ...>     title: "`/errors` type is not array"
+        ...>   }
+        ...> )
+        {:ok, "{\\"title\\":\\"`/errors` type is not array\\"}"}
+
+    """
+    def encode(error = %@for{}, options) do
+       map = for {field, value} <- Map.from_struct(error), value != nil, into: %{}, do: {field, value}
+
+       Poison.Encoder.Map.encode(map, options)
+    end
+  end
 end

--- a/lib/alembic/error.ex
+++ b/lib/alembic/error.ex
@@ -1,0 +1,49 @@
+defmodule Alembic.Error do
+  @moduledoc """
+  [Error objects](http://jsonapi.org/format/#error-objects) provide additional information about problems encountered
+  while performing an operation. Error objects **MUST** be returned as an array keyed by `errors` in the top level of a
+  JSON API document.
+  """
+
+  alias Alembic.Links
+  alias Alembic.Meta
+  alias Alembic.Source
+
+  defstruct code: nil,
+            detail: nil,
+            id: nil,
+            links: nil,
+            meta: nil,
+            source: nil,
+            status: nil,
+            title: nil
+
+  # Types
+
+  @typedoc """
+  Additional information about problems encountered while performing an operation.
+
+  An error object **MAY** have the following members:
+
+  * `code` - an application-specific error code.
+  * `detail` - a human-readable explanation specific to this occurrence of the problem.
+  * `id` - a unique identifier for this particular occurrence of the problem.
+  * `links` - contains the following members:
+      * `"about"` - an `Alembic.Link.link` leading to further details about this particular occurrence of the problem.
+  * `meta` - non-standard meta-information about the error.
+  * `source` - contains references to the source of the error, optionally including any of the following members:
+  * `status` - the HTTP status code applicable to this problem.
+  * `title` - a short, human-readable summary of the problem that **SHOULD NOT** change from occurrence to occurrence of
+    the problem, except for purposes of localization.
+  """
+  @type t :: %__MODULE__{
+               code: String.t,
+               detail: String.t,
+               id: String.t,
+               links: Links.t,
+               meta: Meta.t,
+               source: Source.t,
+               status: String.t,
+               title: String.t
+             }
+end

--- a/lib/alembic/from_json.ex
+++ b/lib/alembic/from_json.ex
@@ -1,0 +1,713 @@
+defmodule Alembic.FromJson do
+  @moduledoc """
+  JSON objects that have constrained members in the [JSON API format](http://jsonapi.org/format/) are represented as
+  `struct`s.  In order to convert plain, decoded JSON in `map`s and `list`s, `from_json/2` can be implemented by a
+  module to convert to its `struct`.
+  """
+
+  alias Alembic.Document
+  alias Alembic.Error
+
+  # Types
+
+  @typedoc """
+  The action that generated the `Alembic.json`.  `:create` and `:update` allow additional formats.
+  """
+  @type action :: :create | :delete | :fetch | :update
+
+  @typedoc """
+  A result that can collect `singleton_result`s.
+  """
+  @type collectable_ok :: {:ok, collectable_value}
+
+  @type collectable_result :: collectable_ok | error
+
+  @typedoc """
+  A value that can collect `singleton_value`s.
+  """
+  @type collectable_value :: list | map | struct
+
+  @typedoc """
+  Tagged-tuple returned when an error has occured in `from_json/2`.
+
+  The format errors are in the errors section of the `Alembic.Document.t`, which can be sent back to
+  sender of the original JSON API document so they can correct the errors.
+  """
+  @type error :: {:error, Document.t}
+
+  @typedoc """
+  The name of a field in a struct
+  """
+  @type field :: atom
+
+  @typedoc """
+  A result that has been tagged with the `field` in a struct to which it should be put when merged to the
+  `collectable_ok`.
+  """
+  @type field_ok :: {:ok, {field, singleton_value}}
+
+  @type field_result :: field_ok | error
+
+  @typedoc """
+  A key in a map or struct output from `from_json/2`
+  """
+  @type key :: field | String.t
+
+  @typedoc """
+  A result that has been tagged with the `key` in a struct or map to which it should be put when merged to the
+  `collectable_ok`.
+  """
+  @type key_ok :: {:ok, {key, singleton_value}}
+
+  @type key_result :: key_ok | error
+
+  @typedoc """
+  Whether the `:client` or `:server` sent the `json`.  The `:client` is allowed more formats on `:create` and `:update`
+  `action`
+  """
+  @type sender :: :client | :server
+
+  @typedoc """
+  A result that can be merged into a `collectable_ok` whose `collectable_value` is a `list`.
+  """
+  @type singleton_ok :: {:ok, singleton_value}
+
+  @type singleton_result :: singleton_ok | error
+
+  @typedoc """
+  A single value that can be merged into a `collective_value`.
+  """
+  @type singleton_value :: map | nil | String.t | struct
+
+  # Callbacks
+
+  @doc """
+  Takes decoded JSON, such as from `Poison.decode/1`, and validates it for format and converts it to struct.
+
+  # Parameters
+
+  * `Alembic.json` - the decoded JSON from `Poison.decode/1` or some other JSON decoder.
+  * `%Alembic.Error{
+       meta: %{
+         "action" => Alembic.FromJson.action,
+         "sender" => Alembic.FromJson.sender
+       },
+       source: %Alembic.Source{
+                 parameter: nil,
+                 pointer: Alembic.json_pointer
+               }
+     }` - A prepolated error that includes a pointer for error repointing and meta information that influencing
+     validation.  For example, some formats are only accepted on `:create` or `:update` from the `:client`.
+
+  # Returns
+
+  * `{:ok, map | struct}` - A validated type from under `Alembic`.
+  * `{:error, %Alembic.Document{errors: [Alembic.Error.t]}}` - one or more errors was
+    encountered when converting from decoded JSON to a validated JSON API document.  The format errors are in the errors
+    section of the `Alembic.Document.t`, which can be sent back to sender of the original JSON API
+    document so they can correct the errors.
+
+    **NOTE: the `meta` from the passed in `Alembic.Error` should not be in the returned
+    `Alembic.Document.t`'s `errors`, as that `meta` information is an implementation detail and for
+    internal use in recursive calls to `Alembic.FromJson.from_json/2` only.**
+  """
+  @callback from_json(Alembic.json, Error.t) :: singleton_result
+
+  # Functions
+
+  @doc """
+  Converts a JSON array using the `element_module` or `element_from_json` function.
+
+  The `element_module` **MUST** implement the `Alembic.FromJson` behaviour.
+  """
+  @spec from_json_array(Alembic.json, Error.t, module) :: {:ok, [singleton_value]} | error
+  def from_json_array(json_array, error_template, element_module) when is_list(json_array) and
+                                                                       is_atom(element_module) do
+    from_json_array(json_array, error_template, &element_module.from_json/2)
+  end
+
+  @spec from_json_array(Alembic.json, Error.t, (Alembic.json, Error.t -> singleton_result)) ::
+        {:ok, [singleton_value]} | error
+  def from_json_array(json_array, error_template, element_from_json) when is_list(json_array) and
+                                                                          is_function(element_from_json, 2) do
+    json_array
+    |> Stream.with_index
+    |> Stream.map(fn {element_json, index} ->
+         element_from_json.(element_json, Error.descend(error_template, index))
+       end)
+    |> reduce({:ok, []})
+  end
+
+  def from_json_array(_, error_template, _) do
+    error = Error.type(error_template, "array")
+
+    {
+      :error,
+      # gets around circular reference if using %Document{} because from_json is implemented by Document and this needs
+      # to return a Document
+      struct(Document, errors: [error])
+    }
+  end
+
+  @doc """
+  Converts the member of a json object into a `field_result` that can be merged into a struct.
+
+  ## Examples
+
+  ### No Member
+
+  If there is no member, then :error will be returned
+
+      iex> Alembic.FromJson.from_parent_json_to_field_result(
+      ...>   %{
+      ...>     field: :data,
+      ...>     member: %{
+      ...>       module: Alembic.ResourceLinkage,
+      ...>       name: "data"
+      ...>     },
+      ...>     parent: %{
+      ...>       json: %{},
+      ...>       error_template: %Alembic.Error{
+      ...>         source: %Alembic.Source{
+      ...>           pointer: "/data/relationships/author"
+      ...>         }
+      ...>       }
+      ...>     }
+      ...>   }
+      ...> )
+      :error
+
+  ### `nil` member value
+
+  If there is a member, but it's value is `nil` (meaning it was `null` in the unparsed JSON) then `nil` will be passed
+  to the `member_module`'s `from_json/2` callback.  In most cases, the implementation should return `{:ok, nil}`, which
+  will be tagged with the `field_name`.
+
+      iex> Alembic.FromJson.from_parent_json_to_field_result(
+      ...>   %{
+      ...>     field: :links,
+      ...>     member: %{
+      ...>       module: Alembic.Links,
+      ...>       name: "links"
+      ...>     },
+      ...>     parent: %{
+      ...>       json: %{"links" => nil},
+      ...>       error_template: %Alembic.Error{
+      ...>         source: %Alembic.Source{
+      ...>           pointer: "/data/relationships/author"
+      ...>         }
+      ...>       }
+      ...>     }
+      ...>   }
+      ...> )
+      {:ok, {:links, nil}}
+
+  ### Error on member
+
+  Any errors from `member_module`'s `from_json/2` will be returned, but with the origin set to `parent_origin`
+
+      iex> Alembic.FromJson.from_parent_json_to_field_result(
+      ...>   %{
+      ...>     field: :links,
+      ...>     member: %{
+      ...>       module: Alembic.Links,
+      ...>       name: "links"
+      ...>     },
+      ...>     parent: %{
+      ...>       json: %{"links" => []},
+      ...>       error_template: %Alembic.Error{
+      ...>         source: %Alembic.Source{
+      ...>           pointer: "/data/relationships/author"
+      ...>         }
+      ...>       }
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data/relationships/author/links` type is not links object",
+              meta: %{
+                "type" => "links object"
+              },
+              source: %Alembic.Source{
+                pointer: "/data/relationships/author/links"
+              },
+              status: "422",
+              title: "Type is wrong"
+            }
+          ]
+        }
+      }
+
+  ## Returns
+
+  * `{:ok, {field_name, value}}` - a value (converted by `member_module`'s `from_json/2`) tagged with the `field_name`,
+    so that it can be passed to `merge/2`.
+  * `{:error, %Alembic.Document{errors: [Alembic.Error.t]}}` - an error from
+    `member_module`'s `from_json/2`.
+  * `:error` if the `member_name` isn't in `parent_json` at all.  This is to help distinguish no member from `nil`
+    member values, as JSON API allows for `null` members in the case of empty to-one relationships.
+
+  """
+  @spec from_parent_json_to_field_result(
+    %{parent: %{json: Alembic.json_object, error_template: Error.t},
+      member: %{name: String.t, from_json: (Alembic.json, Origin.t -> singleton_result)} |
+              %{name: String.t, module: module},
+      field: atom}) :: field_result | error | :error
+
+  def from_parent_json_to_field_result(options = %{member: %{name: member_name, module: member_module}}) do
+    from_parent_json_to_field_result(
+      %{options | member: %{name: member_name, from_json: &member_module.from_json/2}}
+    )
+  end
+
+  def from_parent_json_to_field_result(%{
+                                         field: field_name,
+                                         member: %{name: member_name, from_json: from_json},
+                                         parent: %{json: parent_json, error_template: parent_error_template}
+                                       }) do
+    case Map.fetch(parent_json, member_name) do
+      {:ok, value_json} ->
+        member_error_template = Error.descend(parent_error_template, member_name)
+
+        value_json
+        |> from_json.(member_error_template)
+        |> put_key(field_name)
+      :error ->
+        :error
+    end
+  end
+
+  @doc """
+  Merges the `singleton_result` into the `collectable_result`.
+
+  ## `collectable_ok`
+
+  If the `collectable_result` is a `collectable_ok`, then the `singleton_result` controls whether another
+  `collectable_ok` or `error` is produced.
+
+  ### `error`
+
+  If the `singleton_result` is an error, then it becomes the merged result
+
+      iex> collectable_ok = {:ok, ["One"]}
+      iex> error = {
+      ...>   :error,
+      ...>   %Alembic.Document{
+      ...>     errors: [
+      ...>       %Alembic.Error{
+      ...>         source: %Alembic.Source{
+      ...>           pointer: "/data/1"
+      ...>         }
+      ...>       }
+      ...>     ]
+      ...>   }
+      ...> }
+      ...> merged_result = Alembic.FromJson.merge(collectable_ok, error)
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              source: %Alembic.Source{
+                pointer: "/data/1"
+              }
+            }
+          ]
+        }
+      }
+      iex> merged_result == error
+      true
+
+  ### `field_ok`
+
+  If the the result being merged in is for a field, then the field in the struct in `collectable_ok` is updated with the
+  value from the `field_ok`.
+
+      iex> collectable_ok = {:ok, %Alembic.Link{}}
+      iex> Alembic.FromJson.merge(
+      ...>   collectable_ok,
+      ...>   {:ok, {:href, "http://example.com"}}
+      ...> )
+      {
+        :ok,
+        %Alembic.Link{
+          href: "http://example.com"
+        }
+      }
+
+  ### `key_ok`
+
+  If the result being merged is for a key, then the key in the map in `collectable_ok` is updated with the value from
+  `key_ok`
+
+      iex> collectable_ok = {:ok, %{}}
+      iex> Alembic.FromJson.merge(
+      ...>   collectable_ok,
+      ...>   {
+      ...>     :ok,
+      ...>     {
+      ...>       "link_object",
+      ...>       %Alembic.Link{
+      ...>         href: "http://example.com",
+      ...>         meta: %{
+      ...>           "last_updated_on" => "2015-12-21"
+      ...>         }
+      ...>       }
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %{
+          "link_object" => %Alembic.Link{
+            href: "http://example.com",
+            meta: %{"last_updated_on" => "2015-12-21"}
+          }
+        }
+      }
+
+  ### `singleton_ok`
+
+  If the result being merged is a singleton value, then it is add to the head of `collectable_ok`'s `list`.
+
+      iex> collectable_ok = {:ok, []}
+      iex> Alembic.FromJson.merge(
+      ...>   collectable_ok,
+      ...>   {
+      ...>     :ok,
+      ...>     %Alembic.Error{
+      ...>       source: %Alembic.Source{
+      ...>         pointer: "/data"
+      ...>       }
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        [
+          %Alembic.Error{
+            source: %Alembic.Source{
+              pointer: "/data"
+            }
+          }
+        ]
+      }
+
+  ## `error`
+
+  ### `ok`
+
+  If the current collectable is an `error`, then ok results are ignored
+
+      iex> error = {
+      ...>   :error,
+      ...>   %Alembic.Document{
+      ...>     errors: [
+      ...>       %Alembic.Error{
+      ...>         source: %Alembic.Source{
+      ...>           pointer: "/data/0"
+      ...>         }
+      ...>       }
+      ...>     ]
+      ...>   }
+      ...> }
+      iex> merged_error = Alembic.FromJson.merge(
+      ...>   error,
+      ...>   {:ok, {:field, "value"}}
+      ...> )
+      iex> merged_error == error
+      true
+
+  ### `error`
+
+  If the collectable is an `error` and the `singleton_result` is also an error, then the
+  `Alembic.Document.t` are merged so that `singleton_result`'s errors appear at the head of merged errors.
+
+      iex> error = {
+      ...>   :error,
+      ...>   %Alembic.Document{
+      ...>     errors: [
+      ...>       %Alembic.Error{
+      ...>         source: %Alembic.Source{
+      ...>           pointer: "/data/0"
+      ...>         }
+      ...>       }
+      ...>     ]
+      ...>   }
+      ...> }
+      iex> Alembic.FromJson.merge(
+      ...>   error,
+      ...>   {
+      ...>     :error,
+      ...>     %Alembic.Document{
+      ...>       errors: [
+      ...>         %Alembic.Error{
+      ...>           source: %Alembic.Source{
+      ...>             pointer: "/data/1"
+      ...>           }
+      ...>         }
+      ...>       ]
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              source: %Alembic.Source{
+                pointer: "/data/1"
+              }
+            },
+            %Alembic.Error{
+              source: %Alembic.Source{
+                pointer: "/data/0"
+              }
+            }
+          ]
+        }
+      }
+
+  If you want to get the `Alembic.Document.t` `errors` back in orginal order, use `reverse/1`.  `reduce/2`
+  automatically does the `reverse/1`.
+  """
+  def merge(collable_result, singleton_result)
+
+  @spec merge({:ok, list}, {:ok, singleton_value}) :: {:ok, list}
+  def merge({:ok, list}, {:ok, value}) when is_list(list), do: {:ok, [value | list]}
+
+  @spec merge({:ok, map}, {:ok, {key, singleton_value}}) :: {:ok, map}
+  def merge({:ok, map}, {:ok, {key, value}}) when is_map(map) and is_binary(key), do: {:ok, Map.put(map, key, value)}
+
+  @spec merge({:ok, struct}, {:ok, field, singleton_value}) :: {:ok, struct}
+  def merge({:ok, updatable = %{__struct__: _}}, {:ok, {field, value}}) when is_atom(field) do
+    {:ok, :maps.update(field, value, updatable)}
+  end
+
+  @spec merge(collectable_ok, error) :: error
+  def merge({:ok, _}, error = {:error, _}), do: error
+
+  @spec merge(error, key_ok) :: error
+  def merge(error = {:error, _}, {:ok, _}), do: error
+
+  @spec merge(error, error) :: error
+  def merge({:error, collectable}, {:error, singleton}), do: {:error, Document.merge(collectable, singleton)}
+
+  @doc """
+  Add `key` to `singleton_ok` tuple, otherwise, does nothing.
+
+  When result is `singleton_ok`, adds the key
+
+      iex> Alembic.FromJson.put_key({:ok, %{}}, :data)
+      {:ok, {:data, %{}}}
+
+  But will not add a key if already present
+
+      iex> try do
+      ...>   Alembic.FromJson.put_key({:ok, {:data, %{}}}, :data)
+      ...> rescue
+      ...>   error -> error
+      ...> end
+      %FunctionClauseError{arity: 2, function: :put_key, module: Alembic.FromJson}
+
+  When result is `error`, does nothing
+
+      iex> result = {
+      ...>   :error,
+      ...>   %Alembic.Document{
+      ...>     errors: [
+      ...>       %Alembic.Error{
+      ...>         source: %Alembic.Source{
+      ...>           pointer: "/data"
+      ...>         }
+      ...>       }
+      ...>     ]
+      ...>   }
+      ...> }
+      iex> Alembic.FromJson.put_key(result, :data) == result
+      true
+
+  """
+  def put_key(result, key)
+
+  @spec put_key({:ok, value}, key) :: {:ok, {key, value}} when key: String.t | atom, value: singleton_value
+  def put_key({:ok, value}, key) when (is_atom(key) or is_binary(key)) and not is_tuple(value), do: {:ok, {key, value}}
+
+  @spec put_key(error, key) :: error when key: atom
+  def put_key(error = {:error, _}, _), do: error
+
+  @doc """
+  Reduces `singleton_results` into an `Alembic.FromJson.collectable_result`.
+
+  If there are any errors in singleton_results, then all the errors are accumulated into a single
+  `Alembic.FromJson.error`.
+  """
+  @spec reduce([singleton_result] | Enumerable.t, collectable_result) :: collectable_result
+  def reduce(singleton_results, collectable_result) do
+    singleton_results
+    |> Enum.reduce(
+         collectable_result,
+         fn
+           (:error, acc) ->
+             acc
+           (singleton_result, acc) ->
+             merge(acc, singleton_result)
+         end
+       )
+    |> reverse
+  end
+
+  @doc """
+  Since `merge/2` adds new `singleton_values` to the beginning of a `collectable_ok` list or
+  `Alembic.Error.t`s to the beginning of the `Alembic.Document.t` `errors`, those lists
+  need to be reversed to maintain original ordering after a series of `merge/2` calls.
+
+  ## `error`
+
+  Reverses the `Alembic.Document.t` `errors` to undo tail prepending done by `merge/2`
+
+      iex> accumulated_error = {
+      ...>   :error,
+      ...>   %Alembic.Document{
+      ...>     errors: [
+      ...>       %Alembic.Error{
+      ...>         detail: "The index `2` of `/data` is not a resource",
+      ...>         source: %Alembic.Source{
+      ...>           pointer: "/data/2"
+      ...>         },
+      ...>         title: "Element is not a resource"
+      ...>       },
+      ...>       %Alembic.Error{
+      ...>         detail: "The index `1` of `/data` is not a resource",
+      ...>         source: %Alembic.Source{
+      ...>           pointer: "/data/1"
+      ...>         },
+      ...>         title: "Element is not a resource"
+      ...>       }
+      ...>     ]
+      ...>   }
+      ...> }
+      iex> Alembic.FromJson.reverse(accumulated_error)
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "The index `1` of `/data` is not a resource",
+              source: %Alembic.Source{
+                pointer: "/data/1"
+              },
+              title: "Element is not a resource"
+            },
+            %Alembic.Error{
+              detail: "The index `2` of `/data` is not a resource",
+              source: %Alembic.Source{
+                pointer: "/data/2"
+              },
+              title: "Element is not a resource"
+            }
+          ]
+        }
+      }
+
+  # `collectable_ok`
+
+  ## lists
+
+  List are ordered, but collect by prepending, so they need to be reversed
+
+      iex> collectable_ok = {:ok, [3..4, 1..2]}
+      iex> Alembic.FromJson.reverse(collectable_ok)
+      {:ok, [1..2, 3..4]}
+
+  ## maps
+
+  Maps are unordered, so they just pass through
+
+      iex> collectable_ok = {:ok, %{"b" => 2, "a" => 1}}
+      iex> reversed_ok = Alembic.FromJson.reverse(collectable_ok)
+      {:ok, %{"a" => 1, "b" => 2}}
+      iex> reversed_ok == collectable_ok
+      true
+
+  """
+  def reverse(collectable_result)
+
+  @spec reverse(error) :: error
+  def reverse({:error, document}), do: {:error, Document.reverse(document)}
+
+  @spec reverse({:ok, list}) :: {:ok, list}
+  def reverse({:ok, list}) when is_list(list), do: {:ok, Enum.reverse(list)}
+
+  @spec reverse({:ok, map}) :: {:ok, map}
+  def reverse({:ok, map}) when is_map(map), do: {:ok, map}
+
+  @doc """
+  Ensures that `json` is a `String.t`
+
+  A string will be returned in an `ok` tuple
+
+      iex> Alembic.FromJson.string_from_json(
+      ...>   "422",
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/errors/0/status"
+      ...>     }
+      ...>   }
+      ...> )
+      {:ok, "422"}
+
+  A non-string will be returned in an `error` tuple where the errors `Alembic.Document.t` has a member
+  type error
+
+      iex> Alembic.FromJson.string_from_json(
+      ...>   422,
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/errors/0/status"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/errors/0/status` type is not string",
+              meta: %{
+                "type" => "string"
+              },
+              source: %Alembic.Source{
+                pointer: "/errors/0/status"
+              },
+              status: "422",
+              title: "Type is wrong"
+            }
+          ]
+        }
+      }
+
+  """
+  def string_from_json(json, error_template)
+
+  @spec string_from_json(String.t, Error.t) :: {:ok, String.t}
+  def string_from_json(string, _) when is_binary(string), do: {:ok, string}
+
+  # Alembic.json -- [String.t]
+  @spec string_from_json(nil | true | false | list | float | integer | Alembic.json_object, Error.t) :: error
+  def string_from_json(_, error_template) do
+    {
+      :error,
+      struct(
+        Document,
+        errors: [
+          Error.type(error_template, "string")
+        ]
+      )
+    }
+  end
+end

--- a/lib/alembic/link.ex
+++ b/lib/alembic/link.ex
@@ -1,0 +1,34 @@
+defmodule Alembic.Link do
+  @moduledoc """
+  A [link object](http://jsonapi.org/format/#document-links) represents a URL and metadata about it.
+  """
+
+  alias Alembic.Meta
+
+  # Constants
+
+  @human_type "a link object"
+
+  # Struct
+
+  defstruct href: nil,
+            meta: nil
+
+  # Types
+
+  @typedoc """
+  An [link object](http://jsonapi.org/format/#document-links) which can contain the following members:
+  * `href` - the link's URL.
+  * `meta` - contains non-standard meta-information about the link.
+  """
+  @type t :: %__MODULE__{
+               href: String.t | nil,
+               meta: Meta.t | nil
+             }
+
+  @typedoc """
+  * a `String.t` containing the link's URL.
+  * a `t`
+  """
+  @type link :: String.t | t
+end

--- a/lib/alembic/link.ex
+++ b/lib/alembic/link.ex
@@ -3,11 +3,28 @@ defmodule Alembic.Link do
   A [link object](http://jsonapi.org/format/#document-links) represents a URL and metadata about it.
   """
 
+  alias Alembic
+  alias Alembic.Document
+  alias Alembic.Error
+  alias Alembic.FromJson
   alias Alembic.Meta
+
+  # Behaviours
+
+  @behaviour FromJson
 
   # Constants
 
-  @human_type "a link object"
+  @human_type "link object"
+
+  @meta_options %{
+                  field: :meta,
+                  member: %{
+                    module: Meta,
+                    name: "meta"
+                  },
+                  parent: nil
+                }
 
   # Struct
 
@@ -31,4 +48,246 @@ defmodule Alembic.Link do
   * a `t`
   """
   @type link :: String.t | t
+
+  # Functions
+
+  @doc """
+  Converts JSON to a `link`.
+
+  A `link` can be a `String.t`, so strings will just pass through.  A `link` can also be a `t`, in which case the JSON
+  object is checked for `href`.
+
+  ## Strings
+
+  A string will pass through as simple URLs are allowed.
+
+      iex> url = "http://example.com"
+      iex> {:ok, url} == Alembic.Link.from_json(
+      ...>   url,
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/links/0"
+      ...>     }
+      ...>   }
+      ...> )
+      true
+
+  ## Objects
+
+  URLs can be annotated using "link objects" with an `"href"` and `"meta"`
+
+      iex> Alembic.Link.from_json(
+      ...>   %{
+      ...>     "href" => "http://example.com",
+      ...>     "meta" => %{
+      ...>       "last_updated_on" => "2015-12-21"
+      ...>     }
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/links/0"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Alembic.Link{
+          href: "http://example.com",
+          meta: %{
+            "last_updated_on" => "2015-12-21"
+          }
+        }
+      }
+
+  However, the [JSON API spec](http://jsonapi.org/format/#document-links) only says a "link object" `'can contain'`
+  `href` and `meta`, not that it **MUST**, so no members are actually required in a "link object"
+
+      iex> Alembic.Link.from_json(
+      ...>   %{},
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/links/0"
+      ...>     }
+      ...>   }
+      ...> )
+      {:ok, %Alembic.Link{}}
+
+  The wording does mean that the "link" if not a String must be a JSON object (i.e. an Elixir `map`)
+
+      iex> Alembic.Link.from_json(
+      ...>   ["http://example.com"],
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/links/0"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/links/0` type is not link object",
+              meta: %{
+                "type" => "link object"
+              },
+              source: %Alembic.Source{
+                pointer: "/links/0"
+              },
+              status: "422",
+              title: "Type is wrong"
+            }
+          ]
+        }
+      }
+
+  While `href` is optional, if present, must be a `String.t`
+
+      iex> Alembic.Link.from_json(
+      ...>   %{"href" => []},
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/links/0"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/links/0/href` type is not string",
+              meta: %{
+                "type" => "string"
+              },
+              source: %Alembic.Source{
+                pointer: "/links/0/href"
+              },
+              status: "422",
+              title: "Type is wrong"
+            }
+          ]
+        }
+      }
+
+  Likewise, `meta`, if present, must be a JSON object (i.e. an Elixir `map`)
+
+      iex> Alembic.Link.from_json(
+      ...>   %{"meta" => "© 2015"},
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/links/0"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/links/0/meta` type is not meta object",
+              meta: %{
+                "type" => "meta object"
+              },
+              source: %Alembic.Source{
+                pointer: "/links/0/meta"
+              },
+              status: "422",
+              title: "Type is wrong"
+            }
+          ]
+        }
+      }
+
+  If there are errors in both `href` and `meta`, they will accumulate so all errors can be corrected in a second request
+
+      iex> Alembic.Link.from_json(
+      ...>   %{
+      ...>     "href" => [],
+      ...>     "meta" => "© 2015"
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/links/0"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/links/0/href` type is not string",
+              meta: %{
+                "type" => "string"
+              },
+              source: %Alembic.Source{
+                pointer: "/links/0/href"
+              },
+              status: "422",
+              title: "Type is wrong"
+            },
+            %Alembic.Error{
+              detail: "`/links/0/meta` type is not meta object",
+              meta: %{
+                "type" => "meta object"
+              },
+              source: %Alembic.Source{
+                pointer: "/links/0/meta"
+              },
+              status: "422",
+              title: "Type is wrong"
+            }
+          ]
+        }
+      }
+
+  """
+
+  @spec from_json(String.t, Error.t) :: {:ok, String.t}
+  def from_json(string, _) when is_binary(string) do
+    {:ok, string}
+  end
+
+  @spec from_json(Alembic.json_object, Error.t) :: {:ok, t} | FromJson.error
+  def from_json(json = %{}, error_template = %Error{}) do
+    parent = %{json: json, error_template: error_template}
+
+    href_result = FromJson.from_parent_json_to_field_result %{
+      field: :href,
+      member: %{
+        from_json: &href_from_json/2,
+        name: "href"
+      },
+      parent: parent
+    }
+    meta_result = FromJson.from_parent_json_to_field_result %{@meta_options | parent: parent}
+    results = [href_result, meta_result]
+
+    results
+    |> FromJson.reduce({:ok, %__MODULE__{}})
+  end
+
+  # Alembic.json -- [Alembic.json_object, String.t]
+  @spec from_json(nil | true | false | list | float | integer, Error.t) :: FromJson.error
+  def from_json(_, error_template) do
+    {
+      :error,
+      %Document{
+        errors: [
+          Error.type(error_template, @human_type)
+        ]
+      }
+    }
+  end
+
+  ## Private Functions
+
+  @spec href_from_json(nil, Error.t) :: {:ok, nil}
+  def href_from_json(nil, _), do: {:ok, nil}
+
+  @spec href_from_json(String.t, Error.t) :: {:ok, String.t}
+  # Alembic.json -- [nil, String.t]
+  @spec href_from_json(true | false | list | float | integer | Alembic.json_object, Error.t) :: FromJson.error
+  def href_from_json(href, error_template), do: FromJson.string_from_json(href, error_template)
 end

--- a/lib/alembic/links.ex
+++ b/lib/alembic/links.ex
@@ -8,7 +8,19 @@ defmodule Alembic.Links do
   > </cite>
   """
 
+  alias Alembic
+  alias Alembic.Document
+  alias Alembic.Error
+  alias Alembic.FromJson
   alias Alembic.Link
+
+  # Behaviours
+
+  @behaviour FromJson
+
+  # Constants
+
+  @human_type "links object"
 
   # Types
 
@@ -16,4 +28,194 @@ defmodule Alembic.Links do
   Maps `String.t` name to `Alembic.Link.link`
   """
   @type t :: %{String.t => Link.link}
+
+  # Functions
+
+  @doc """
+  Validates that the given `json` follows the spec for ["links"](http://jsonapi.org/format/#document-links) and converts
+  any child "links" to `Alembic.Link`.
+
+  In a most locations, `"links"` is optional, so it can be nil.
+
+      iex> Alembic.Links.from_json(
+      ...>   nil,
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/links"
+      ...>     }
+      ...>   }
+      ...> )
+      {:ok, nil}
+
+  # Links
+
+  > The value of each `links` member MUST be an object (a "links object").
+  >
+  > -- <cite>
+  >  [JSON API - Document Structure - Links](http://jsonapi.org/format/#document-links)
+  > </cite>
+
+      iex> Alembic.Links.from_json(
+      ...>   ["http://example.com"],
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/links"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/links` type is not links object",
+              meta: %{
+                "type" => "links object"
+              },
+              source: %Alembic.Source{
+                pointer: "/links"
+              },
+              status: "422",
+              title: "Type is wrong"
+            }
+          ]
+        }
+      }
+
+  Because the members of a "links object" are free-form, even an empty object is ok
+
+      iex> Alembic.Links.from_json(
+      ...>   %{},
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/links"
+      ...>     }
+      ...>   }
+      ...> )
+      {:ok, %{}}
+
+  # Link values
+
+  > Each member of a links object is a "link". A link MUST be represented as either:
+  >
+  > * a string containing the link's URL.
+  > * an object ("link object") which can contain the following members:
+  >   * `href` - a string containing the link's URL.
+  >   * `meta` - a meta object containing non-standard meta-information about the link.
+  >
+  > -- <cite>
+  >  [JSON API - Document Structure - Links](http://jsonapi.org/format/#document-links)
+  > </cite>
+
+      iex> Alembic.Links.from_json(
+      ...>   %{
+      ...>     "string" => "http://example.com",
+      ...>     "link_object" => %{
+      ...>       "href" => "http://example.com",
+      ...>       "meta" => %{
+      ...>         "last_updated_on" => "2015-12-21"
+      ...>       }
+      ...>     }
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/links"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %{
+          "link_object" => %Alembic.Link{
+            href: "http://example.com",
+            meta: %{
+              "last_updated_on" => "2015-12-21"
+            }
+          },
+          "string" => "http://example.com"
+        }
+      }
+
+  When any link has an error, then only errors will be returned, but errors from later links will be included
+
+      iex> Alembic.Links.from_json(
+      ...>   %{
+      ...>     "first_ok" => "http://example.com/first_ok",
+      ...>     "first_error" => [],
+      ...>     "second_ok" => "http://example.com/second_ok",
+      ...>     "second_error" => []
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/links"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/links/first_error` type is not link object",
+              meta: %{
+                "type" => "link object"
+              },
+              source: %Alembic.Source{
+                pointer: "/links/first_error"
+              },
+              status: "422",
+              title: "Type is wrong"
+            },
+            %Alembic.Error{
+              detail: "`/links/second_error` type is not link object",
+              meta: %{
+                "type" => "link object"
+              },
+              source: %Alembic.Source{
+                pointer: "/links/second_error"
+              },
+              status: "422",
+              title: "Type is wrong"
+            }
+          ]
+        }
+      }
+
+  """
+  def from_json(json, error_template)
+
+  @spec from_json(Alembic.json_object, Error.t) :: {:ok, map} | FromJson.error
+  def from_json(link_by_name = %{}, error_template) do
+    link_by_name
+    |> Enum.reduce({:ok, %{}}, &validate_link_pair(&1, &2, error_template))
+    |> FromJson.reverse
+  end
+
+  @spec from_json(nil, Error.t) :: {:ok, nil}
+  def from_json(nil, _), do: {:ok, nil}
+
+  # Alembic.json -- [Alembic.json_object, nil]
+  @spec from_json(true | false | list | float | integer | String.t, Error.t) :: FromJson.error
+  def from_json(_, error_template) do
+    {
+      :error,
+      %Document{
+        errors: [
+          Error.type(error_template, @human_type)
+        ]
+      }
+    }
+  end
+
+  ## Private Functions
+
+  defp validate_link_pair({key, value_json}, collectable_result, error_template) do
+    key_error_template = Error.descend(error_template, key)
+
+    field_result = value_json
+                   |> Link.from_json(key_error_template)
+                   |> FromJson.put_key(key)
+
+    FromJson.merge(collectable_result, field_result)
+  end
 end

--- a/lib/alembic/links.ex
+++ b/lib/alembic/links.ex
@@ -1,0 +1,19 @@
+defmodule Alembic.Links do
+  @moduledoc """
+  > Where specified, a `links` member can be used to represent links. The value of each `links` member **MUST** be an
+  > object (a "links object").
+  >
+  > -- <cite>
+  >  [JSON API - Document Structure - Links](http://jsonapi.org/format/#document-links)
+  > </cite>
+  """
+
+  alias Alembic.Link
+
+  # Types
+
+  @typedoc """
+  Maps `String.t` name to `Alembic.Link.link`
+  """
+  @type t :: %{String.t => Link.link}
+end

--- a/lib/alembic/meta.ex
+++ b/lib/alembic/meta.ex
@@ -8,7 +8,101 @@ defmodule Alembic.Meta do
   > </cite>
   """
 
+  alias Alembic.Document
+  alias Alembic.Error
+  alias Alembic.FromJson
+
+  # Behaviours
+
+  @behaviour FromJson
+
+  # Constants
+
+  @human_type "meta object"
+
   # Types
 
   @type t :: Alembic.json_object
+
+  # Functions
+
+  @doc """
+  Converts raw JSON to a "meta object"
+
+  "meta objects" have no defined fields, so all keys remain unchanged.
+
+      iex> Alembic.Meta.from_json(
+      ...>   %{"copyright" => "© 2015"},
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/meta"
+      ...>     }
+      ...>   }
+      ...> )
+      {:ok, %{"copyright" => "© 2015"}}
+
+  > The value of each meta member MUST be an object (a “meta object”).
+  >
+  > -- <cite>
+  >  [JSON API - Document Structure - Meta Information](http://jsonapi.org/format/#document-meta)
+  > </cite>
+
+      iex> Alembic.Meta.from_json(
+      ...>   "© 2015",
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/meta"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/meta` type is not meta object",
+              meta: %{
+                "type" => "meta object"
+              },
+              source: %Alembic.Source{
+                pointer: "/meta"
+              },
+              status: "422",
+              title: "Type is wrong"
+            }
+          ]
+        }
+      }
+
+  However, `meta` is optional in most locations, so `nil` is also allowed
+
+      iex> Alembic.Meta.from_json(
+      ...>   nil,
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/meta"
+      ...>     }
+      ...>   }
+      ...> )
+      {:ok, nil}
+
+  """
+  def from_json(json, error_template)
+
+  @spec from_json(Alembic.json_object, Error.t) :: {:ok, map}
+  @spec from_json(nil, Error.t) :: {:ok, nil}
+  def from_json(meta, _) when is_map(meta) or is_nil(meta), do: {:ok, meta}
+
+  # the rest of Alembic.json
+  @spec from_json(true | false | list | float | integer | String.t, Error.t) :: FromJson.error
+  def from_json(_, error_template) do
+    {
+      :error,
+      %Document{
+        errors: [
+          Error.type(error_template, @human_type)
+        ]
+      }
+    }
+  end
 end

--- a/lib/alembic/meta.ex
+++ b/lib/alembic/meta.ex
@@ -1,0 +1,14 @@
+defmodule Alembic.Meta do
+  @moduledoc """
+  > Where specified, a `meta` member can be used to include non-standard meta-information. The value of each `meta`
+  > member **MUST** be an object (a "meta object").
+  >
+  > -- <cite>
+  >  [JSON API - Document Structure - Meta Information](http://jsonapi.org/format/#document-meta)
+  > </cite>
+  """
+
+  # Types
+
+  @type t :: Alembic.json_object
+end

--- a/lib/alembic/source.ex
+++ b/lib/alembic/source.ex
@@ -233,4 +233,39 @@ defmodule Alembic.Source do
 
     FromJson.merge({:ok, %__MODULE__{}}, field_result)
   end
+
+  defimpl Poison.Encoder do
+    @doc """
+    Encoded `Alembic.Source.t` as a `String.t` contain a JSON object with either a `"parameter"` or `"pointer"` member.
+    Whichever field is `nil` in the `Alembic.Source.t` does not appear in the output.
+
+    If `parameter` is set in the `Alembic.Source.t`, then the encoded JSON will only have "parameter"
+
+        iex> Poison.encode(
+        ...>   %Alembic.Source{
+        ...>     parameter: "q"
+        ...>   }
+        ...> )
+        {:ok, "{\\"parameter\\":\\"q\\"}"}
+
+    If `pointer` is set in the `Alembic.Source.t`, then the encoded JSON will only have "pointer"
+
+        iex> Poison.encode(
+        ...>   %Alembic.Source{
+        ...>     pointer: "/data"
+        ...>   }
+        ...> )
+        {:ok, "{\\"pointer\\":\\"/data\\"}"}
+
+    """
+    @spec encode(@for.t, Keyword.t) :: String.t
+
+    def encode(%@for{parameter: parameter, pointer: nil}, options) when is_binary(parameter) do
+      Poison.Encoder.Map.encode(%{"parameter" => parameter}, options)
+    end
+
+    def encode(%@for{parameter: nil, pointer: pointer}, options) when is_binary(pointer) do
+      Poison.Encoder.Map.encode(%{"pointer" => pointer}, options)
+    end
+  end
 end

--- a/lib/alembic/source.ex
+++ b/lib/alembic/source.ex
@@ -1,0 +1,24 @@
+defmodule Alembic.Source do
+  @moduledoc """
+  The `source` of an error.
+  """
+
+  alias Alembic
+
+  defstruct [:parameter, :pointer]
+
+  # Types
+
+  @typedoc """
+  An object containing references to the source of the [error](http://jsonapi.org/format/#error-objects), optionally
+  including any of the following members:
+
+  * `pointer` - JSON Pointer ([RFC6901](https://tools.ietf.org/html/rfc6901)) to the associated entity in the request
+    document (e.g. `"/data"` for a primary data object, or `"/data/attributes/title"` for a specific attribute).
+  * `parameter` - URL query parameter caused the error.
+  """
+  @type t :: %__MODULE__{
+               parameter: String.t,
+               pointer: Api.json_pointer
+             }
+end

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Alembic.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger]]
+    [applications: [:logger, :poison]]
   end
 
   # Dependencies can be Hex packages:
@@ -46,7 +46,9 @@ defmodule Alembic.Mixfile do
       # documentation coverage
       {:inch_ex, "~> 0.5.1", only: [:dev, :test]},
       # formats test output for CircleCI
-      {:junit_formatter, "~> 1.0", only: :test}
+      {:junit_formatter, "~> 1.0", only: :test},
+      # JSON decode and encoding.  Protocols are implemented for Alembic.* structs
+      {:poison, "~> 2.1"}
     ]
   end
 end

--- a/test/alembic/document_test.exs
+++ b/test/alembic/document_test.exs
@@ -5,5 +5,24 @@ defmodule Alembic.DocumentTest do
 
   use ExUnit.Case, async: true
 
-  doctest Alembic.Document
+  alias Alembic.Document
+  alias Alembic.Error
+  alias Alembic.FromJsonTest
+  alias Alembic.Source
+
+  doctest Document
+
+  test "Poison.encode -> Poison.decode -> from_json/2 is idempotent for errors document" do
+    error_template = %Error{
+      source: %Source{
+        pointer: ""
+      }
+    }
+
+    {:error, response} = Document.from_json(%{}, error_template)
+
+    FromJsonTest.assert_idempotent error_template: error_template,
+                                   module: Document,
+                                   original: response
+  end
 end

--- a/test/alembic/document_test.exs
+++ b/test/alembic/document_test.exs
@@ -1,0 +1,9 @@
+defmodule Alembic.DocumentTest do
+  @moduledoc """
+  Run doctests for `Alembic.Document`
+  """
+
+  use ExUnit.Case, async: true
+
+  doctest Alembic.Document
+end

--- a/test/alembic/error_test.exs
+++ b/test/alembic/error_test.exs
@@ -1,0 +1,9 @@
+defmodule Alembic.ErrorTest do
+  @moduledoc """
+  Runs doctests for `Alembic.Error`
+  """
+
+  use ExUnit.Case, async: true
+
+  doctest Alembic.Error
+end

--- a/test/alembic/error_test.exs
+++ b/test/alembic/error_test.exs
@@ -5,5 +5,55 @@ defmodule Alembic.ErrorTest do
 
   use ExUnit.Case, async: true
 
-  doctest Alembic.Error
+  alias Alembic.Error
+  alias Alembic.FromJsonTest
+  alias Alembic.Source
+
+  # Constants
+
+  # Tests
+
+  doctest Error
+
+  test "conflicting -> Poison.encode -> Poison.decode -> from_json is idempotent" do
+    %Error{
+      source: %Source{
+        pointer: "/errors/0/source"
+      }
+    }
+    |> Error.conflicting(~w{parameter pointer})
+    |> assert_idempotent
+  end
+
+  test "missing -> Poison.encode -> Poison.decode -> from_json is idempotent" do
+    %Error{
+      source: %Source{
+        pointer: ""
+      }
+    }
+    |> Error.missing("data")
+    |> assert_idempotent
+  end
+
+  test "type -> Poison.encode -> Poison.decode -> from_json is idempotent" do
+    %Error{
+      source: %Source{
+        pointer: "/errors"
+      }
+    }
+    |> Error.type("array")
+    |> assert_idempotent
+  end
+
+  # Private Functions
+
+  defp assert_idempotent(original) do
+    FromJsonTest.assert_idempotent error_template: %Error{
+                                                     source: %Source{
+                                                       pointer: "/errors/0"
+                                                     }
+                                                   },
+                                   module: Error,
+                                   original: original
+  end
 end

--- a/test/alembic/from_json_test.exs
+++ b/test/alembic/from_json_test.exs
@@ -1,0 +1,9 @@
+defmodule Alembic.FromJsonTest do
+  @moduledoc """
+  Runs doctests for `Alembic.FromJson`
+  """
+
+  use ExUnit.Case, async: true
+
+  doctest Alembic.FromJson
+end

--- a/test/alembic/from_json_test.exs
+++ b/test/alembic/from_json_test.exs
@@ -5,5 +5,21 @@ defmodule Alembic.FromJsonTest do
 
   use ExUnit.Case, async: true
 
+  # Functions
+
+  def assert_idempotent(options) do
+    error_template = Keyword.get options, :error_template
+    module = Keyword.get options, :module
+    original = Keyword.get options, :original
+
+    {:ok, encoded} = Poison.encode(original)
+    {:ok, decoded} = Poison.decode(encoded)
+    {:ok, from_decoded} = module.from_json(decoded, error_template)
+
+    assert from_decoded == original
+  end
+
+  # Tests
+
   doctest Alembic.FromJson
 end

--- a/test/alembic/link_test.exs
+++ b/test/alembic/link_test.exs
@@ -1,0 +1,9 @@
+defmodule Alembic.LinkTest do
+  @moduledoc """
+  Runs doctests for `Alembic.Link`
+  """
+
+  use ExUnit.Case, async: true
+
+  doctest Alembic.Link
+end

--- a/test/alembic/links_test.exs
+++ b/test/alembic/links_test.exs
@@ -1,0 +1,9 @@
+defmodule Alembic.LinksTest do
+  @moduledoc """
+  Runs doctests for `Alembic.Links`
+  """
+
+  use ExUnit.Case, async: true
+
+  doctest Alembic.Links
+end

--- a/test/alembic/meta_test.exs
+++ b/test/alembic/meta_test.exs
@@ -1,0 +1,9 @@
+defmodule Alembic.MetaTest do
+  @moduledoc """
+  Runs doctests for `Alembic.Meta`
+  """
+
+  use ExUnit.Case, async: true
+
+  doctest Alembic.Meta
+end

--- a/test/alembic/source_test.exs
+++ b/test/alembic/source_test.exs
@@ -1,0 +1,9 @@
+defmodule Alembic.SourceTest do
+  @moduledoc """
+  Runs doctests for `Alembic.Source`
+  """
+
+  use ExUnit.Case, async: true
+
+  doctest Alembic.Source
+end

--- a/test/alembic/source_test.exs
+++ b/test/alembic/source_test.exs
@@ -5,5 +5,31 @@ defmodule Alembic.SourceTest do
 
   use ExUnit.Case, async: true
 
-  doctest Alembic.Source
+  alias Alembic.FromJsonTest
+  alias Alembic.Error
+  alias Alembic.Source
+
+  # Tests
+
+  doctest Source
+
+  test "Poison.encode -> Poison.decode -> from_json/2 is idempotent when `parameter` is set" do
+    assert_idempotent %Source{parameter: "q"}
+  end
+
+  test "Poison.encode -> Poison.decode -> from_json/2 is idempotent when `pointer` is set" do
+    assert_idempotent %Source{pointer: "/data"}
+  end
+
+  # Private Functions
+
+  defp assert_idempotent(original) do
+    FromJsonTest.assert_idempotent error_template: %Error{
+                                                     source: %Source{
+                                                       pointer: "/errors/0/source"
+                                                     }
+                                                   },
+                                   module: Source,
+                                   original: original
+  end
 end

--- a/test/poison/encoder/alembic/error_test.exs
+++ b/test/poison/encoder/alembic/error_test.exs
@@ -1,0 +1,9 @@
+defmodule Poison.Encoder.Alembic.ErrorTest do
+  @moduledoc """
+  Runs doctess for Poison.Encoder implementation for `Alembic.Error`
+  """
+
+  use ExUnit.Case, async: true
+
+  doctest Poison.Encoder.Alembic.Error
+end

--- a/test/poison/encoder/alembic/source_test.exs
+++ b/test/poison/encoder/alembic/source_test.exs
@@ -1,0 +1,9 @@
+defmodule Poison.Encoder.Alembic.SourceTest do
+  @moduledoc """
+  Runs doctess for Poison.Encoder implementation for `Alembic.Source`
+  """
+
+  use ExUnit.Case, async: true
+
+  doctest Poison.Encoder.Alembic.Source
+end


### PR DESCRIPTION
# Changelog
## Enhancements
  * JSON API errors documents can be validated and converted to `%Alembic.Document{}` using `Alembic.Document.from_json/2`.  Invalid documents return `{:error, %Alembic.Document{}}`.  The `%Alembic.Document{}` can be sent back to the sender, which can be validated on the other end using `from_json/2`.  Valid documents return `{:ok, %Alembic.Document{}}`.
