### PR TITLE
JSON API (non-errors) Documents

### DIFF
--- a/lib/alembic/document.ex
+++ b/lib/alembic/document.ex
@@ -5,26 +5,135 @@ defmodule Alembic.Document do
 
   alias Alembic.Error
   alias Alembic.FromJson
+  alias Alembic.Links
+  alias Alembic.Meta
+  alias Alembic.Resource
+  alias Alembic.ResourceLinkage
 
   # Behaviours
 
   @behaviour FromJson
 
+  # Constants
+
+  @data_options %{
+                  field: :data,
+                  member: %{
+                    module: ResourceLinkage,
+                    name: "data"
+                  }
+                }
+
+  @errors_options %{
+                    field: :errors,
+                    member: %{
+                      name: "errors"
+                    }
+                  }
+
+  @included_options %{
+                      field: :included,
+                      member: %{
+                        name: "included"
+                      }
+                    }
+
+  @human_type "document"
+
+  @links_options %{
+                   field: :links,
+                   member: %{
+                     module: Links,
+                     name: "links"
+                   }
+                 }
+
+  @minimum_children ~w{data errors meta}
+
+  @meta_options %{
+                  field: :meta,
+                  member: %{
+                    module: Meta,
+                    name: "meta"
+                  }
+                }
+
+  # DOES NOT include `@errors_options` because `&FromJson.from_json_array(&1, &2, Error)` cannot appear in a module
+  #   attribute used in a function
+  # DOES NOT include `@included_options` because `&FromJson.from_json_array(&1, &2, Resource)` cannot appear in a module
+  #   attribute used in a function
+  @child_options_list [
+    @data_options,
+    @links_options,
+    @meta_options
+  ]
+
   # Struct
 
-  defstruct errors: nil
+  defstruct ~w{data errors included links meta}a
 
   # Types
 
   @typedoc """
   A JSON API [Document](http://jsonapi.org/format/#document-structure).
 
+  ## Data
+
+  When there are no errors, `data` are returned in the document and `errors` are not returned in the document.
+
+  | Field      | Included/Excluded/Optional |
+  |------------|----------------------------|
+  | `data`     | Included                   |
+  | `errors`   | Excluded                   |
+  | `included` | Optional                   |
+  | `links`    | Optional                   |
+  | `meta`     | Optional                   |
+
   ## Errors
 
-  When an error occurs, only `errors` are returned in the document.
+  When an error occurs, `errors` are returned in the document and `data` are not returned in the document.
+
+  | Field      | Included/Excluded/Optional |
+  |------------|----------------------------|
+  | `data`     | Excluded                   |
+  | `errors`   | Included                   |
+  | `included` | Excluded                   |
+  | `links`    | Optional                   |
+  | `meta`     | Optional                   |
+
+  ## Meta
+
+  JSON API allows a `meta` only document, in which case `data` and `errors` are not returned in the document.
+
+  | Field      | Included/Excluded/Optional |
+  |------------|----------------------------|
+  | `data`     | Excluded                   |
+  | `errors`   | Excluded                   |
+  | `included` | Excluded                   |
+  | `links`    | Optional                   |
+  | `meta`     | Included                   |
+
   """
   @type t :: %__MODULE__{
+               data: nil,
                errors: [Error.t],
+               included: nil,
+               links: Links.t | nil,
+               meta: Meta.t | nil
+             } |
+             %__MODULE__{
+               data: nil,
+               errors: nil,
+               included: nil,
+               links: Links.t | nil,
+               meta: Meta.t
+             } |
+             %__MODULE__{
+               data: [Resource.t] | Resource.t,
+               errors: nil,
+               included: [Resource.t] | nil,
+               links: Links.t | nil,
+               meta: Meta.t | nil
              }
 
   # Functions
@@ -32,7 +141,288 @@ defmodule Alembic.Document do
   @doc """
   Converts a JSON object into a JSON API Document, `t`.
 
-  ## Error documents
+  ## Data documents
+
+  ### Single
+
+  An empty single resource can represented as `"data": null` in encoded JSON, so it comes into `from_json` as
+  `data: nil`
+
+      iex> Alembic.Document.from_json(
+      ...>   %{ "data" => nil },
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: ""
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Alembic.Document{
+          data: nil
+        }
+      }
+
+  A present single can be a resource
+
+      iex> Alembic.Document.from_json(
+      ...>   %{
+      ...>     "data" => %{
+      ...>       "attributes" => %{
+      ...>         "text" => "First Post!"
+      ...>       },
+      ...>       "id" => "1",
+      ...>       "type" => "post"
+      ...>     }
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: ""
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Alembic.Document{
+          data: %Alembic.Resource{
+            attributes: %{
+              "text" => "First Post!"
+            },
+            id: "1",
+            type: "post"
+          }
+        }
+      }
+
+  ... or a present single can be just a resource identifier
+
+      iex> Alembic.Document.from_json(
+      ...>   %{
+      ...>     "data" => %{
+      ...>       "id" => "1",
+      ...>       "type" => "post"
+      ...>     }
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: ""
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Alembic.Document{
+          data: %Alembic.ResourceIdentifier{
+            id: "1",
+            type: "post"
+          }
+        }
+      }
+
+  You notice that whether a JSON object in `"data"` is treated as a `Alembic.Resource.t` or
+  `Alembic.ResourceIdentifier.t` hinges on whether `"attributes"` or `"relationships"` is present as those
+  members are only allowed for resources.
+
+  ### Collection
+
+  #### Resources
+
+  A collection can be a list of resources
+
+     iex> Alembic.Document.from_json(
+     ...>   %{
+     ...>     "data" => [
+     ...>       %{
+     ...>         "attributes" => %{
+     ...>           "text" => "First Post!"
+     ...>         },
+     ...>         "id" => "1",
+     ...>         "relationships" => %{
+     ...>           "comments" => %{
+     ...>             "data" => [
+     ...>               %{
+     ...>                 "id" => "1",
+     ...>                 "type" => "comment"
+     ...>               }
+     ...>             ]
+     ...>           }
+     ...>         },
+     ...>         "type" => "post"
+     ...>       }
+     ...>     ]
+     ...>   },
+     ...>   %Alembic.Error{
+     ...>     meta: %{
+     ...>       "action" => :create,
+     ...>       "sender" => :client
+     ...>     },
+     ...>     source: %Alembic.Source{
+     ...>       pointer: ""
+     ...>     }
+     ...>   }
+     ...> )
+     {
+       :ok,
+       %Alembic.Document{
+         data: [
+           %Alembic.Resource{
+             attributes: %{
+               "text" => "First Post!"
+             },
+             id: "1",
+             relationships: %{
+               "comments" => %Alembic.Relationship{
+                 data: [
+                   %Alembic.ResourceIdentifier{
+                     id: "1",
+                     type: "comment"
+                   }
+                 ]
+               }
+             },
+             type: "post"
+           }
+         ]
+       }
+     }
+
+  With `"relationships"`, a resources collection can optionally have `"included"` for the attributes for the resource
+  identifiers.  If `"included"` is not given or the `"id"` and `"type"` for a resource identifier, then the resource
+  identifier should just be considered a foreign key reference that needs to be fetched with another API query.
+
+     iex> Alembic.Document.from_json(
+     ...>   %{
+     ...>     "data" => [
+     ...>       %{
+     ...>         "attributes" => %{
+     ...>           "text" => "First Post!"
+     ...>         },
+     ...>         "id" => "1",
+     ...>         "relationships" => %{
+     ...>           "comments" => %{
+     ...>             "data" => [
+     ...>               %{
+     ...>                 "id" => "1",
+     ...>                 "type" => "comment"
+     ...>               }
+     ...>             ]
+     ...>           }
+     ...>         },
+     ...>         "type" => "post"
+     ...>       }
+     ...>     ],
+     ...>     "included" => [
+     ...>       %{
+     ...>         "attributes" => %{
+     ...>           "text" => "First Comment!"
+     ...>         },
+     ...>         "id" => "1",
+     ...>         "type" => "comment"
+     ...>       }
+     ...>     ]
+     ...>   },
+     ...>   %Alembic.Error{
+     ...>     meta: %{
+     ...>       "action" => :create,
+     ...>       "sender" => :client
+     ...>     },
+     ...>     source: %Alembic.Source{
+     ...>       pointer: ""
+     ...>     }
+     ...>   }
+     ...> )
+     {
+       :ok,
+       %Alembic.Document{
+         data: [
+           %Alembic.Resource{
+             attributes: %{
+               "text" => "First Post!"
+             },
+             id: "1",
+             relationships: %{
+               "comments" => %Alembic.Relationship{
+                 data: [
+                   %Alembic.ResourceIdentifier{
+                     id: "1",
+                     type: "comment"
+                   }
+                 ]
+               }
+             },
+             type: "post"
+           }
+         ],
+         included: [
+           %Alembic.Resource{
+             attributes: %{
+               "text" => "First Comment!"
+             },
+             id: "1",
+             type: "comment"
+           }
+         ]
+       }
+     }
+
+  #### Resource Identifiers
+
+  Or a list of resource identifiers
+
+      iex> Alembic.Document.from_json(
+      ...>   %{
+      ...>     "data" => [
+      ...>       %{
+      ...>         "id" => "1",
+      ...>         "type" => "post"
+      ...>       }
+      ...>     ]
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: ""
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Alembic.Document{
+          data: [
+            %Alembic.ResourceIdentifier{
+              id: "1",
+              type: "post"
+            }
+          ]
+        }
+      }
+
+  #### Empty
+
+  An empty collection can be signified with `[]`.  Because there is no type information, it's not possible to tell
+  whether it is an empty list of `Alembic.Resource.t` or `Alembic.ResourceIdentifier.t`.
+
+      iex> Alembic.Document.from_json(
+      ...>   %{
+      ...>     "data" => []
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: ""
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Alembic.Document{
+          data: []
+        }
+      }
+
+  ## Errors documents
 
   Errors from the sender must have an `"errors"` key set to a list of errors.
 
@@ -134,7 +524,38 @@ defmodule Alembic.Document do
         }
       }
 
-  If `"errors"` isn't even present, it will be a different error.
+  ## Meta documents
+
+  Returned documents can contain just `"meta"` with neither `"data"` nor `"errors"`
+
+      iex> Alembic.Document.from_json(
+      ...>   %{
+      ...>     "meta" => %{
+      ...>       "copyright" => "2016"
+      ...>     }
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :server
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: ""
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Alembic.Document{
+          meta: %{
+            "copyright" => "2016"
+          }
+        }
+      }
+
+  ## Incomplete documents
+
+  If neither `"errors"`, `"data"`, nor `"meta"` is present, then the document is invalid and a `Alembic.
 
       iex> Alembic.Document.from_json(
       ...>   %{},
@@ -153,37 +574,46 @@ defmodule Alembic.Document do
         %Alembic.Document{
           errors: [
             %Alembic.Error{
-              detail: "`/errors` is missing",
+              detail: "At least one of the following children of `` must be present:\\n" <>
+                      "data\\n" <>
+                      "errors\\n" <>
+                      "meta",
               meta: %{
-                "child" => "errors"
+                "children" => [
+                  "data",
+                  "errors",
+                  "meta"
+                ]
               },
               source: %Alembic.Source{
                 pointer: ""
               },
               status: "422",
-              title: "Child missing"
+              title: "Not enough children"
             }
-          ]
+          ],
         }
       }
 
   """
   def from_json(json, error_template)
 
-  def from_json(%{"errors" => errors}, error_template = %Error{}) do
-    field_result = errors
-                   |> FromJson.from_json_array(Error.descend(error_template, "errors"), Error)
-                   |> FromJson.put_key(:errors)
+  def from_json(json = %{}, error_template) do
+    parent = %{error_template: error_template, json: json}
 
-    FromJson.merge({:ok, %__MODULE__{}}, field_result)
+    child_options_list
+    |> Stream.map(&Map.put(&1, :parent, parent))
+    |> Stream.map(&FromJson.from_parent_json_to_field_result/1)
+    |> FromJson.reduce({:ok, %__MODULE__{}})
+    |> validate_minimum_children(json, error_template)
   end
 
-  def from_json(%{}, error_template = %Error{}) do
+  def from_json(_, error_template) do
     {
       :error,
       %__MODULE__{
         errors: [
-          Error.missing(error_template, "errors")
+          Error.type(error_template, @human_type)
         ]
       }
     }
@@ -198,8 +628,8 @@ defmodule Alembic.Document do
   def merge(first, second)
 
   @spec merge(%__MODULE__{errors: [Error.t]}, %__MODULE__{errors: [Error.t]}) :: %__MODULE__{errors: [Error.t]}
-  def merge(%__MODULE__{errors: first_errors}, %__MODULE__{errors: second_errors})
-      when is_list(first_errors) and is_list(second_errors) do
+  def merge(%__MODULE__{errors: first_errors}, %__MODULE__{errors: second_errors}) when is_list(first_errors) and
+                                                                                        is_list(second_errors) do
     %__MODULE__{
       # Don't use Enum.into as it will reverse the list immediately, which is more reversing that necessary since
       # merge is called a bunch of time in sequence.
@@ -254,5 +684,149 @@ defmodule Alembic.Document do
   """
   def reverse(document = %__MODULE__{errors: errors}) when is_list(errors) do
     %__MODULE__{document | errors: Enum.reverse(errors)}
+  end
+
+  ## Private functions
+
+  @spec child_options_list :: [map, ...]
+  defp child_options_list do
+    [errors_options, included_options | @child_options_list]
+  end
+
+  @spec errors_options :: map
+  defp errors_options do
+    put_in @errors_options[:member][:from_json], &FromJson.from_json_array(&1, &2, Error)
+  end
+
+  @spec included_options :: map
+  defp included_options do
+    put_in @included_options[:member][:from_json], &FromJson.from_json_array(&1, &2, Resource)
+  end
+
+  # Whether `json` has at least one of `"data"`, `"errors"`, `"meta"`
+  @spec minimum_children?(Alembic.json_object) :: boolean
+  defp minimum_children?(json), do: Enum.any? @minimum_children, &Map.has_key?(json, &1)
+
+  @spec minimum_children_error(Error.t) :: FromJson.error
+  defp minimum_children_error(error_template) do
+    {
+      :error,
+      %__MODULE__{
+        errors: [
+          Error.minimum_children(error_template, @minimum_children)
+        ]
+      }
+    }
+  end
+
+  @spec validate_minimum_children({:ok, t}, Alembic.json_object, Error.t) :: {:ok, t} | FromJson.error
+  @spec validate_minimum_children({:error, t}, Alembic.json_object, Error.t) :: FromJson.error
+  defp validate_minimum_children(collectable_result, json, error_template) do
+    if minimum_children?(json) do
+      collectable_result
+    else
+      FromJson.merge(collectable_result, minimum_children_error(error_template))
+    end
+  end
+
+  # Protocol Implementations
+
+  defimpl Poison.Encoder do
+    alias Alembic.Document
+
+    @doc """
+    ## Data
+
+    A `nil` data is preserved as `"data": null` in JSON API represents an empty single resource as long as there aren't
+    `errors`.
+
+        iex> Poison.encode(
+        ...>   %Alembic.Document{
+        ...>     data: nil
+        ...>   }
+        ...> )
+        {:ok, "{\\"data\\":null}"}
+
+    ## Errors
+
+    When there are `errors`, a `nil` `data` is not encoded as `errors` are exclusive from `data`
+
+        iex> Poison.encode(
+        ...>   %Alembic.Document{
+        ...>     data: nil,
+        ...>     errors: [
+        ...>       %Alembic.Error{
+        ...>         source: %Alembic.Source{
+        ...>           pointer: ""
+        ...>         }
+        ...>       }
+        ...>     ]
+        ...>   }
+        ...> )
+        {:ok, "{\\"errors\\":[{\\"source\\":{\\"pointer\\":\\"\\"}}],\\"data\\":null}"}
+
+    ## Meta
+
+    Since `"meta"` can be sent with either `"data"` or `"errors"` and `"data"` can be `nil` for empty single resource,
+    to get an encoding with only `"meta"`, you need to use an option: `drop: [:data]`.
+
+        iex> Poison.encode(
+        ...>   %Alembic.Document{
+        ...>     data: nil,
+        ...>     meta: %{
+        ...>       "copyright" => "2016"
+        ...>     }
+        ...>   },
+        ...>   drop: [:data]
+        ...> )
+        {:ok, "{\\"meta\\":{\\"copyright\\":\\"2016\\"}}"}
+
+    ## Invalid
+
+    `"data"` and `"errors"` cannot exist in the same JSON API document, so they will fail to encode
+
+        iex> try do
+        ...>   Poison.encode(
+        ...>     %Alembic.Document{
+        ...>       data: [],
+        ...>       errors: [
+        ...>         %Alembic.Error{
+        ...>           source: %Alembic.Source{
+        ...>             pointer: ""
+        ...>           }
+        ...>         }
+        ...>       ]
+        ...>     }
+        ...>   )
+        ...> rescue
+        ...>   e in ArgumentError -> e
+        ...> end
+        %ArgumentError{
+           message: "`data` and `errors` is exclusive in JSON API, but both are set: data is `[]` and errors is " <>
+                    "`[%Alembic.Error{code: nil, detail: nil, id: nil, links: nil, meta: nil, " <>
+                    "source: %Alembic.Source{parameter: nil, pointer: \\"\\"}, " <>
+                    "status: nil, title: nil}]`"
+        }
+
+    """
+
+    def encode(%Document{data: data, errors: errors}, _) when not is_nil(data) and not is_nil(errors) do
+      raise ArgumentError,
+            "`data` and `errors` is exclusive in JSON API, but both are set: data is `#{inspect data}` and errors " <>
+            "is `#{inspect errors}`"
+    end
+
+    def encode(document = %Document{}, options) do
+      # `data: nil` is allowed to be encoded as `"data": null` because `null` `"data"` is an empty single resource
+      map = for {field, value} <- Map.from_struct(document),
+                field == :data || value != nil,
+                into: %{},
+                do: {field, value}
+
+      drop = Keyword.get(options, :drop, [])
+      map = Map.drop(map, drop)
+
+      Poison.Encoder.Map.encode(map, options)
+    end
   end
 end

--- a/lib/alembic/error.ex
+++ b/lib/alembic/error.ex
@@ -269,6 +269,54 @@ defmodule Alembic.Error do
   end
 
   @doc """
+  When the minimum number of children are not present, give the sender a list of the children they could have sent.
+
+      iex> Alembic.Error.minimum_children(
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/author"
+      ...>     }
+      ...>   },
+      ...>   ~w{data links meta}
+      ...> )
+      %Alembic.Error{
+        detail: "At least one of the following children of `/data/relationships/author` must be present:\\n" <>
+                "data\\n" <>
+                "links\\n" <>
+                "meta",
+        meta: %{
+          "children" => [
+            "data",
+            "links",
+            "meta"
+          ]
+        },
+        source: %Alembic.Source{
+          pointer: "/data/relationships/author"
+        },
+        status: "422",
+        title: "Not enough children"
+      }
+
+  """
+  @spec minimum_children(t, [String.t]) :: t
+  def minimum_children(template, children)
+
+  def minimum_children(%__MODULE__{source: source = %Source{pointer: parent_pointer}},
+                       children) when is_list(children) do
+    %__MODULE__{
+      detail: "At least one of the following children of `#{parent_pointer}` must be present:\n" <>
+              Enum.join(children, "\n"),
+      meta: %{
+        "children" => children
+      },
+      source: source,
+      status: "422",
+      title: "Not enough children"
+    }
+  end
+
+  @doc """
   When a required (**MUST** in the spec) member is missing
 
   # Top-level member is missing

--- a/lib/alembic/from_json.ex
+++ b/lib/alembic/from_json.ex
@@ -77,7 +77,7 @@ defmodule Alembic.FromJson do
   @typedoc """
   A single value that can be merged into a `collective_value`.
   """
-  @type singleton_value :: map | nil | String.t | struct
+  @type singleton_value :: [struct] | map | nil | String.t | struct
 
   # Callbacks
 

--- a/lib/alembic/from_json.ex
+++ b/lib/alembic/from_json.ex
@@ -177,6 +177,46 @@ defmodule Alembic.FromJson do
       ...> )
       :error
 
+  If there is no member, and the `:member` map contains `required: true`, then an error will be returned that the member
+  is missing
+
+      iex> Alembic.FromJson.from_parent_json_to_field_result(
+      ...>   %{
+      ...>     field: :id,
+      ...>     member: %{
+      ...>       from_json: &Alembic.FromJson.string_from_json/2,
+      ...>       name: "id",
+      ...>       required: true
+      ...>     },
+      ...>     parent: %{
+      ...>       json: %{},
+      ...>       error_template: %Alembic.Error{
+      ...>         source: %Alembic.Source{
+      ...>           pointer: "/data/relationships/author"
+      ...>         }
+      ...>       }
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data/relationships/author/id` is missing",
+              meta: %{
+                "child" => "id"
+              },
+              source: %Alembic.Source{
+                pointer: "/data/relationships/author"
+              },
+              status: "422",
+              title: "Child missing"
+            }
+          ]
+        }
+      }
+
   ### `nil` member value
 
   If there is a member, but it's value is `nil` (meaning it was `null` in the unparsed JSON) then `nil` will be passed
@@ -266,7 +306,7 @@ defmodule Alembic.FromJson do
 
   def from_parent_json_to_field_result(%{
                                          field: field_name,
-                                         member: %{name: member_name, from_json: from_json},
+                                         member: member = %{name: member_name, from_json: from_json},
                                          parent: %{json: parent_json, error_template: parent_error_template}
                                        }) do
     case Map.fetch(parent_json, member_name) do
@@ -277,7 +317,21 @@ defmodule Alembic.FromJson do
         |> from_json.(member_error_template)
         |> put_key(field_name)
       :error ->
-        :error
+        if Map.get(member, :required, false) do
+          {
+            :error,
+            # gets around circular reference if using %Document{} because from_json is implemented by Document and
+            # this needs to return a Document
+            struct(
+              Document,
+              errors: [
+                Error.missing(parent_error_template, member_name)
+              ]
+            )
+          }
+        else
+          :error
+        end
     end
   end
 

--- a/lib/alembic/relationship.ex
+++ b/lib/alembic/relationship.ex
@@ -1,0 +1,381 @@
+defmodule Alembic.Relationship do
+  @moduledoc """
+  > Members of the relationships object ("relationships") represent references from the resource object in which it's
+  > defined to other resource objects.
+  >
+  > Relationships may be to-one or to-many.
+  >
+  > -- <cite>
+  >  [JSON API - Document Structure - Resource Objects -
+  >   Relationships](http://jsonapi.org/format/#document-resource-objects-relationships)
+  > </cite>
+  """
+
+  alias Alembic.Document
+  alias Alembic.Error
+  alias Alembic.FromJson
+  alias Alembic.Links
+  alias Alembic.Meta
+  alias Alembic.ResourceLinkage
+
+  @behaviour FromJson
+
+  # Constants
+
+  @data_options %{
+                  field: :data,
+                  member: %{
+                    module: ResourceLinkage,
+                    name: "data"
+                  },
+                  parent: nil
+                }
+
+  @human_type "relationship"
+
+  @links_options %{
+                   field: :links,
+                   member: %{
+                     module: Links,
+                     name: "links"
+                   },
+                   parent: nil
+                 }
+
+  @meta_options %{
+                  field: :meta,
+                  member: %{
+                    module: Meta,
+                    name: "meta"
+                  },
+                  parent: nil
+                }
+  # Struct
+
+  defstruct data: nil,
+            links: nil,
+            meta: nil
+
+  # Types
+
+  @type resource_identifier :: %{String.t => String.t}
+
+  @typedoc """
+  > A "relationship object" **MUST** contain at least one of the following:
+  >
+  > * `links` - a links object containing at least one of the following:
+  >     * `self` - a link for the relationship itself (a "relationship link"). This link allows the client to directly
+  >        manipulate the relationship. For example, removing an author through an article's relationship URL would
+  >        disconnect the person from the article without deleting the people resource itself. When fetched
+  >        successfully, this link returns the linkage for the related resources as its primary data. (See Fetching
+  >        Relationships.)
+  >     * `related` - a related resource link
+  > * `data` - resource linkage
+  > * `meta` - a meta object that contains non-standard meta-information about the relationship.
+  >
+  > -- <cite>
+  >  [JSON API - Document Structure - Resource Objects -
+  >   Relationships](http://jsonapi.org/format/#document-resource-objects-relationships)
+  > </cite>
+  """
+  @type t :: %__MODULE__{
+               data: [resource_identifier] | resource_identifier,
+               links: Links.links,
+               meta: Alembic.meta
+             }
+
+  # Functions
+
+  @doc """
+
+  # Relationships
+
+  A non-object will be matched, but return an error.
+
+      iex> Alembic.Relationship.from_json(
+      ...>   "1",
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/author"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data/relationships/author` type is not relationship",
+              meta: %{
+                "type" => "relationship"
+              },
+              source: %Alembic.Source{
+                pointer: "/data/relationships/author"
+              },
+              status: "422",
+              title: "Type is wrong"
+            }
+          ]
+        }
+      }
+
+  An object without any of the members will show them as all missing
+
+      iex> Alembic.Relationship.from_json(
+      ...>   %{},
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/author"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "At least one of the following children of `/data/relationships/author` must be present:\\n" <>
+                      "data\\n" <>
+                      "links\\n" <>
+                      "meta",
+              meta: %{
+                "children" => [
+                  "data",
+                  "links",
+                  "meta"
+                ]
+              },
+              source: %Alembic.Source{
+                pointer: "/data/relationships/author"
+              },
+              status: "422",
+              title: "Not enough children"
+            }
+          ]
+        }
+      }
+
+  ## Resource Linkage
+
+  ### To-one
+
+  `"data"` can be a single resource identifier
+
+      iex> Alembic.Relationship.from_json(
+      ...>   %{"data" => %{"id" => "1", "type" => "author"}},
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/author"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Alembic.Relationship{
+          data: %Alembic.ResourceIdentifier{
+            id: "1",
+            type: "author"
+          }
+        }
+      }
+
+  An empty to-one relationship can be signified with `nil` for `"data"`
+
+      iex> Alembic.Relationship.from_json(
+      ...>   %{"data" => nil},
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/author"
+      ...>     }
+      ...>   }
+      ...> )
+      {:ok, %Alembic.Relationship{data: nil}}
+
+  ### To-many
+
+  `"data"` can be a list of resource identifiers
+
+      iex> Alembic.Relationship.from_json(
+      ...>   %{
+      ...>     "data" => [
+      ...>       %{"id" => "1", "type" => "comment"},
+      ...>       %{"id" => "2", "type" => "comment"}
+      ...>     ]
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/comments"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Alembic.Relationship{
+          data: [
+            %Alembic.ResourceIdentifier{id: "1", type: "comment"},
+            %Alembic.ResourceIdentifier{id: "2", type: "comment"}
+          ]
+        }
+      }
+
+  An empty to-many relationship can be signified with `[]`
+
+      iex> Alembic.Relationship.from_json(
+      ...>   %{"data" => []},
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/comments"
+      ...>     }
+      ...>   }
+      ...> )
+      {:ok, %Alembic.Relationship{data: []}}
+
+  ### Invalid
+
+  There are actual, invalid values for resource linkages, such as strings and numbers
+
+      iex> Alembic.Relationship.from_json(
+      ...>   %{"data" => "bad resource linkage"},
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/bad"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data/relationships/bad/data` type is not resource linkage",
+              meta: %{
+                "type" => "resource linkage"
+              },
+              source: %Alembic.Source{
+                pointer: "/data/relationships/bad/data"
+              },
+              status: "422",
+              title: "Type is wrong"
+            }
+          ]
+        }
+      }
+
+  ## Links
+
+  `"links"` if present, must be an object
+
+      iex> Alembic.Relationship.from_json(
+      ...>   %{"links" => ["http://example.com"]},
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/website"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data/relationships/website/links` type is not links object",
+              meta: %{
+                "type" => "links object"
+              },
+              source: %Alembic.Source{
+                pointer: "/data/relationships/website/links"
+              },
+              status: "422",
+              title: "Type is wrong"
+            }
+          ]
+        }
+      }
+
+  Because the "links" name are free-form, they remain strings
+
+      iex> Alembic.Relationship.from_json(
+      ...>   %{"links" => %{"example" => "http://example.com"}},
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/website"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Alembic.Relationship{
+          links: %{
+            "example" => "http://example.com"
+          }
+        }
+      }
+
+  "links" can be mix of `String.t` URLs and `Alembic.Link.t` objects
+
+      iex> Alembic.Relationship.from_json(
+      ...>   %{
+      ...>     "links" => %{
+      ...>       "link_object" => %{
+      ...>          "href" => "http://example.com/link_object/href"
+      ...>       },
+      ...>       "string" => "http://example.com/string"
+      ...>     }
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/website"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Alembic.Relationship{
+          links: %{
+            "link_object" => %Alembic.Link{
+              href: "http://example.com/link_object/href"
+            },
+            "string" => "http://example.com/string"
+          }
+        }
+      }
+  """
+  def from_json(json, error_template)
+
+  @spec from_json(Alembic.json_object, Error.t) :: {:ok, t} | FromJson.error
+  def from_json(json = %{}, error_template = %Error{}) do
+    parent = %{error_template: error_template, json: json}
+
+    data_result = FromJson.from_parent_json_to_field_result %{@data_options | parent: parent}
+    links_result = FromJson.from_parent_json_to_field_result %{@links_options | parent: parent}
+    meta_result = FromJson.from_parent_json_to_field_result %{@meta_options | parent: parent}
+    results = [data_result, links_result, meta_result]
+
+    if Enum.all? results, &(&1 == :error) do
+      {
+        :error,
+        %Document{
+          errors: [
+            Error.minimum_children(error_template, ~w{data links meta})
+          ]
+        }
+      }
+    else
+      results
+      |> FromJson.reduce({:ok, %__MODULE__{}})
+    end
+  end
+
+  # Alembic.json - [Alembic.json_object]
+  @spec from_json(nil | true | false | list | float | integer | String.t, Error.t) :: FromJson.error
+  def from_json(_, error_template) do
+    {
+      :error,
+      %Document{
+        errors: [
+          Error.type(error_template, @human_type)
+        ]
+      }
+    }
+  end
+end

--- a/lib/alembic/relationships.ex
+++ b/lib/alembic/relationships.ex
@@ -1,0 +1,255 @@
+defmodule Alembic.Relationships do
+  @moduledoc """
+  > The value of the `relationships` key MUST be an object (a "relationships object"). Members of the relationships
+  > object ("relationships") represent references from the resource object in which it's defined to other resource
+  > objects.
+  >
+  > Relationships may be to-one or to-many.
+  >
+  > -- <cite>
+  >  [JSON API - Document Structure - Resource Objects -
+  >   Relationships](http://jsonapi.org/format/#document-resource-object-relationships)
+  > </cite>
+  """
+
+  alias Alembic.Document
+  alias Alembic.Error
+  alias Alembic.FromJson
+  alias Alembic.Relationship
+
+  @behaviour FromJson
+
+  # Constants
+
+  @human_type "relationships object"
+
+  # Types
+
+  @type relationship :: Alembic.json_object
+
+  @typedoc """
+  Maps `String.t` name to `relationship`
+  """
+  @type t :: %{String.t => relationship}
+
+  # Functions
+
+  @doc """
+  Validates that the given `json` follows the spec for
+  ["relationship"](http://jsonapi.org/format/#document-resource-object-relationships).
+
+  `"relationships"` is optional, so it can be nil.
+
+      iex> Alembic.Relationships.from_json(
+      ...>   nil,
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships"
+      ...>     }
+      ...>   }
+      ...> )
+      {:ok, nil}
+
+  ## Relationships
+
+  > Members of the relationships object ("relationships") represent references from the resource object in which it's
+  > defined to other resource objects.
+  >
+  > -- <cite>
+  >  [JSON API - Document Structure - Resource Objects -
+  >   Relationships](http://jsonapi.org/format/#document-resource-object-relationships)
+  > </cite>
+
+      iex> Alembic.Relationships.from_json(
+      ...>   %{"shirt" => []},
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data/relationships/shirt` type is not relationship",
+              meta: %{
+                "type" => "relationship"
+              },
+              source: %Alembic.Source{
+                pointer: "/data/relationships/shirt"
+              },
+              status: "422",
+              title: "Type is wrong"
+            }
+          ]
+        }
+      }
+
+  ## Data
+
+  > Resource linkage in a compound document allows a client to link together all of the included resource objects
+  > without having to `GET` any URLs via links.
+  >
+  > Resource linkage **MUST** be represented as one of the following:
+  >
+  > * `null` for empty to-one relationships.
+  > * an empty array (`[]`) for empty to-many relationships.
+  > * a single resource identifier object for non-empty to-one relationships.
+  > * an array of resource identifier objects for non-empty to-many relationships.
+  >
+  > -- <cite>
+  >  [JSON API - Document Structure - Resource Objects -
+  >   Resource Linkage](http://jsonapi.org/format/#document-resource-object-linkage)
+  > </cite>
+
+  ### To-one
+
+  A to-one relationship, when present, will be a single `Alembic.ResourceIdentifier.t`
+
+      iex> Alembic.Relationships.from_json(
+      ...>   %{
+      ...>     "author" => %{
+      ...>       "data" => %{
+      ...>         "id" => "1",
+      ...>         "type" => "author"
+      ...>       }
+      ...>     }
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %{
+          "author" => %Alembic.Relationship{
+            data: %Alembic.ResourceIdentifier{
+              id: "1",
+              type: "author"
+            }
+          }
+        }
+      }
+
+  An empty to-one relationship can be signified with `nil`, which would have been `null` in the original JSON.
+
+      iex> Alembic.Relationships.from_json(
+      ...>   %{
+      ...>     "author" => %{
+      ...>       "data" => nil
+      ...>     }
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %{
+          "author" => %Alembic.Relationship{
+            data: nil
+          }
+        }
+      }
+
+  ### To-many
+
+  A to-many relationship, when preent, will be a list of `Alembic.ResourceIdentifier.t`
+
+      iex> Alembic.Relationships.from_json(
+      ...>   %{
+      ...>     "comments" => %{
+      ...>       "data" => [
+      ...>         %{
+      ...>           "id" => "1",
+      ...>           "type" => "comment"
+      ...>         }
+      ...>       ]
+      ...>     }
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %{
+          "comments" => %Alembic.Relationship{
+            data: [
+              %Alembic.ResourceIdentifier{
+                id: "1",
+                type: "comment"
+              }
+            ]
+          }
+        }
+      }
+
+  An empty to-many resource linkage can be signified with `[]`.
+
+      iex> Alembic.Relationships.from_json(
+      ...>   %{
+      ...>     "comments" => %{
+      ...>       "data" => []
+      ...>     }
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %{
+          "comments" => %Alembic.Relationship{
+            data: []
+          }
+        }
+      }
+
+
+  """
+  def from_json(json, error_template)
+
+  @spec from_json(Alembic.json_object, Error.t) :: {:ok, map} | FromJson.error
+  def from_json(relationship_by_name, error_template = %Error{}) when is_map(relationship_by_name) do
+    relationship_by_name
+    |> Stream.map(&relationship_key_result_from_key_json_pair(&1, error_template))
+    |> FromJson.reduce({:ok, %{}})
+  end
+
+  @spec from_json(nil, Error.t) :: {:ok, nil}
+  def from_json(nil, _), do: {:ok, nil}
+
+  # Alembic.json -- [Alembic.json_object, nil]
+  @spec from_json(true | false | list | float | integer | String.t, Error.t) :: FromJson.error
+  def from_json(_, error_template) do
+    {
+      :error,
+      %Document{
+        errors: [
+          Error.type(error_template, @human_type)
+        ]
+      }
+    }
+  end
+
+  ## Private Functions
+
+  defp relationship_key_result_from_key_json_pair({key, value_json}, parent_error_template) do
+    key_error_template = Error.descend(parent_error_template, key)
+
+    value_json
+    |> Relationship.from_json(key_error_template)
+    |> FromJson.put_key(key)
+  end
+end

--- a/lib/alembic/resource.ex
+++ b/lib/alembic/resource.ex
@@ -1,0 +1,885 @@
+defmodule Alembic.Resource do
+  @moduledoc """
+  The individual JSON object of elements of the list of the `data` member of the
+  [JSON API document](http://jsonapi.org/format/#document-structure) are
+  [resources](http://jsonapi.org/format/#document-resource-objects) as are the members of the `included` member.
+  """
+
+  alias Alembic
+  alias Alembic.Document
+  alias Alembic.Error
+  alias Alembic.FromJson
+  alias Alembic.Links
+  alias Alembic.Meta
+  alias Alembic.Relationships
+
+  @behaviour FromJson
+
+  # Constants
+
+  @attributes_human_type "json object"
+
+  @attributes_options %{
+                        field: :attributes,
+                        member: %{
+                          name: "attributes"
+                        }
+                      }
+
+  @id_options %{
+                field: :id,
+                member: %{
+                  from_json: &FromJson.string_from_json/2,
+                  name: "id"
+                }
+              }
+
+  @links_options %{
+                   field: :links,
+                   member: %{
+                     module: Links,
+                     name: "links"
+                   }
+                 }
+
+  @meta_options %{
+                  field: :meta,
+                  member: %{
+                    module: Meta,
+                    name: "meta"
+                  }
+                }
+
+  @relationships_options %{
+                           field: :relationships,
+                           member: %{
+                             module: Relationships,
+                             name: "relationships"
+                           }
+                         }
+
+  @type_options %{
+                  field: :type,
+                  member: %{
+                    from_json: &FromJson.string_from_json/2,
+                    name: "type",
+                    required: true
+                  }
+                }
+
+  # DOES NOT include `@attribute_options` because it needs to be customized with private function reference
+  # DOES NOT include `@id_options` because it needs to be customized based on `error_template.meta`
+  @child_options_list [
+    @links_options,
+    @meta_options,
+    @relationships_options,
+    @type_options
+  ]
+
+  @human_type "resource"
+
+  # Struct
+
+  defstruct attributes: nil,
+            id: nil,
+            links: nil,
+            meta: nil,
+            relationships: nil,
+            type: nil
+
+  # Types
+
+  @typedoc """
+  Resource objects" appear in a JSON API document to represent resources.
+
+  A resource object **MUST** contain at least the following top-level members:
+
+  * `id`
+  * `type`
+
+  Exception: The `id` member is not required when the resource object originates at the client and represents a new
+  resource to be created on the server. (`%{action: :create, source: :client}`)
+
+  In addition, a resource object **MAY(( contain any of these top-level members:
+
+  * `attributes` - an [attributes object](http://jsonapi.org/format/#document-resource-object-attributes) representing
+    some of the resource's data.
+  * `links` - an `Alembic.Link.links` containing links related to the resource.
+  * `meta` - contains non-standard meta-information about a resource that can not be represented as an attribute or
+    relationship.
+  * `relationships` - a [relationships object](http://jsonapi.org/format/#document-resource-object-relationships)
+    describing relationships between the resource and other JSON API resources.
+  """
+  @type t :: %__MODULE__{
+               attributes: Alembic.json_object | nil,
+               id: String.t | nil,
+               links: Links.t | nil,
+               meta: Meta.t | nil,
+               relationships: Relationships.t | nil,
+               type: String.t
+             }
+
+  # Functions
+
+  @doc """
+  Converts a JSON object into a [JSON API Resource](http://jsonapi.org/format/#document-resource-objects), `t`.
+
+
+  ## Invalid
+
+  A non-resource will be matched, but return an error.
+
+      iex> Alembic.Resource.from_json(
+      ...>   "1",
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data` type is not resource",
+              meta: %{
+                "type" => "resource"
+              },
+              source: %Alembic.Source{
+                pointer: "/data"
+              },
+              status: "422",
+              title: "Type is wrong"
+            }
+          ]
+        }
+      }
+
+  ## Action
+
+  The `Alembic.Error.t` `meta` `"action"` key influences whether `"id"` is required: `"id"` is optional
+  for `"action"` `:create` sent from `"sender"` `:client`; otherwise, it `"id"` is required.
+
+  ### Creating
+
+  Only `"type"` is required when creating a resource from a client because the `"id"` will be assigned by the server.
+
+      iex> Alembic.Resource.from_json(
+      ...>   %{ "type" => "thing" },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {:ok, %Alembic.Resource{type: "thing"}}
+
+  Only `"type"` will be marked as missing when creating a resource from a client
+
+      iex> Alembic.Resource.from_json(
+      ...>   %{},
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data/type` is missing",
+              meta: %{
+                "child" => "type"
+              },
+              source: %Alembic.Source{
+                pointer: "/data"
+              },
+              status: "422",
+              title: "Child missing"
+            }
+          ]
+        }
+      }
+
+  But, normally you'd include some `"attributes"` too
+
+      iex> Alembic.Resource.from_json(
+      ...>   %{
+      ...>     "attributes" => %{
+      ...>       "name" => "Thing 1"
+      ...>     },
+      ...>     "type" => "thing"
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Alembic.Resource{
+          attributes: %{
+            "name" => "Thing 1"
+          },
+          type: "thing"
+        }
+      }
+
+  `"attributes"` are quite free-form, but must still be an `Alembic.json_object`
+
+      iex> Alembic.Resource.from_json(
+      ...>   %{
+      ...>     "attributes" => [
+      ...>       "name"
+      ...>     ],
+      ...>     "type" => "thing"
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data/attributes` type is not json object",
+              meta: %{
+                "type" => "json object"
+              },
+              source: %Alembic.Source{
+                pointer: "/data/attributes"
+              },
+              status: "422",
+              title: "Type is wrong"
+            }
+          ]
+        }
+      }
+
+  ### Deleting
+
+  Only `"id"` and `"type"` is required when when deleting a resource from a client
+
+      iex> Alembic.Resource.from_json(
+      ...>   %{ "id" => "1", "type" => "thing"},
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :delete,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {:ok, %Alembic.Resource{id: "1", type: "thing"}}
+
+  With `"id"`, `"type"` will be marked as missing when deleting a resource from a client
+
+      iex> Alembic.Resource.from_json(
+      ...>   %{ "id" => "1" },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :delete,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data/type` is missing",
+              meta: %{
+                "child" => "type"
+              },
+              source: %Alembic.Source{
+                pointer: "/data"
+              },
+              status: "422",
+              title: "Child missing"
+            }
+          ]
+        }
+      }
+
+  With `"type"`, `"id"` will be marked as missing when deleting a resource from a client
+
+      iex> Alembic.Resource.from_json(
+      ...>   %{ "type" => "thing" },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :delete,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data/id` is missing",
+              meta: %{
+                "child" => "id"
+              },
+              source: %Alembic.Source{
+                pointer: "/data"
+              },
+              status: "422",
+              title: "Child missing"
+            }
+          ]
+        }
+      }
+
+  Both `"id"` and `"type"` will be marked as missing when deleting a resource from a client
+
+      iex> Alembic.Resource.from_json(
+      ...>   %{},
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :delete,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data/id` is missing",
+              meta: %{
+                "child" => "id"
+              },
+              source: %Alembic.Source{
+                pointer: "/data"
+              },
+              status: "422",
+              title: "Child missing"
+            },
+            %Alembic.Error{
+              detail: "`/data/type` is missing",
+              meta: %{
+                "child" => "type"
+              },
+              source: %Alembic.Source{
+                pointer: "/data"
+              },
+              status: "422",
+              title: "Child missing"
+            }
+          ]
+        }
+      }
+
+  ### Updating
+
+  Only `"id"` and `"type"` is required when when updating a resource from a client
+
+      iex> Alembic.Resource.from_json(
+      ...>   %{ "id" => "1", "type" => "thing"},
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :update,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {:ok, %Alembic.Resource{id: "1", type: "thing"}}
+
+  With `"id"`, `"type"` will be marked as missing when upating a resource from a client
+
+      iex> Alembic.Resource.from_json(
+      ...>   %{ "id" => "1" },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :update,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data/type` is missing",
+              meta: %{
+                "child" => "type"
+              },
+              source: %Alembic.Source{
+                pointer: "/data"
+              },
+              status: "422",
+              title: "Child missing"
+            }
+          ]
+        }
+      }
+
+  With `"type"`, `"id"` will be marked as missing when updating a resource from a client
+
+      iex> Alembic.Resource.from_json(
+      ...>   %{ "type" => "thing" },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :update,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data/id` is missing",
+              meta: %{"child" => "id"},
+              source: %Alembic.Source{
+                pointer: "/data"
+              },
+              status: "422",
+              title: "Child missing"
+            }
+          ]
+        }
+      }
+
+  Both `"id"` and `"type"` will be marked as missing when updating a resource from a client
+
+      iex> Alembic.Resource.from_json(
+      ...>   %{},
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :update,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data/id` is missing",
+              meta: %{"child" => "id"},
+              source: %Alembic.Source{
+                pointer: "/data"
+              },
+              status: "422",
+              title: "Child missing"
+            },
+            %Alembic.Error{
+              detail: "`/data/type` is missing",
+              meta: %{
+                "child" => "type"
+              },
+              source: %Alembic.Source{
+                pointer: "/data"
+              },
+              status: "422",
+              title: "Child missing"
+            }
+          ]
+        }
+      }
+
+  ## Optional members
+
+  `"links"`, `"meta"` and `"relationships"` are optional, but if they are present, they **MUST** be valid or their
+  errors will make the overall `t` invalid.
+
+  ### `"links"`
+
+  A valid `"links"` maps link names to either a JSON object with `"href"` and/or `"meta"` member or a `String.t` URL.
+
+      iex> Alembic.Resource.from_json(
+      ...>   %{
+      ...>     "links" => %{
+      ...>        "string" => "http://example.com",
+      ...>       "link_object" => %{
+      ...>         "href" => "http://example.com",
+      ...>         "meta" => %{
+      ...>           "last_updated_on" => "2015-12-21"
+      ...>         }
+      ...>       }
+      ...>     },
+      ...>     "type" => "thing"
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Alembic.Resource{
+          links: %{
+            "link_object" => %Alembic.Link{
+              href: "http://example.com",
+              meta: %{
+                "last_updated_on" => "2015-12-21"
+              }
+            },
+            "string" => "http://example.com"
+          },
+          type: "thing"
+        }
+      }
+
+  Even though `"links"` is optional, if it has errors, those errors will make the entire resource invalid
+
+      iex> Alembic.Resource.from_json(
+      ...>   %{
+      ...>     "links" => ["http://example.com"],
+      ...>     "type" => "thing"
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data/links` type is not links object",
+              meta: %{
+                "type" => "links object"
+              },
+              source: %Alembic.Source{
+                pointer: "/data/links"
+              },
+              status: "422",
+              title: "Type is wrong"
+            }
+          ]
+        }
+      }
+
+  ### `"meta"`
+
+  A valid `"meta"` is any JSON object
+
+      iex> Alembic.Resource.from_json(
+      ...>   %{
+      ...>     "meta" => %{"copyright" => "© 2015"},
+      ...>     "type" => "thing"
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Alembic.Resource{
+          meta: %{
+            "copyright" => "© 2015"
+          },
+          type: "thing"
+        }
+      }
+
+  If `"meta"` isn't a JSON object, then that error will make the whole resource invalid
+
+      iex> Alembic.Resource.from_json(
+      ...>   %{
+      ...>     "meta" => "© 2015",
+      ...>     "type" => "thing"
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data/meta` type is not meta object",
+              meta: %{
+                "type" => "meta object"
+              },
+              source: %Alembic.Source{
+                pointer: "/data/meta"
+              },
+              status: "422",
+              title: "Type is wrong"
+            }
+          ]
+        }
+      }
+
+  ### Relationships
+
+  `"relationships"` allow linking to other resource in the documents `"included"` using resource identifiers
+
+      iex> Alembic.Resource.from_json(
+      ...>   %{
+      ...>     "relationships" => %{
+      ...>       "shirt" => %{
+      ...>         "data" => %{
+      ...>           "id" => "1",
+      ...>           "type" => "shirt"
+      ...>         }
+      ...>       }
+      ...>     },
+      ...>     "type" => "thing"
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Alembic.Resource{
+          relationships: %{
+            "shirt" => %Alembic.Relationship{
+              data: %Alembic.ResourceIdentifier{
+                id: "1",
+                type: "shirt"
+              }
+            }
+          },
+          type: "thing"
+        }
+      }
+
+  If any relationship has an error, then it will make the entire resource invalid
+
+
+      iex> Alembic.Resource.from_json(
+      ...>   %{
+      ...>     "relationships" => %{
+      ...>       "shirt" => %{
+      ...>         "data" => %{}
+      ...>       }
+      ...>     },
+      ...>     "type" => "thing"
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data/relationships/shirt/data/type` is missing",
+              meta: %{
+                "child" => "type"
+              },
+              source: %Alembic.Source{
+                pointer: "/data/relationships/shirt/data"
+              },
+              status: "422",
+              title: "Child missing"
+            },
+            %Alembic.Error{
+              detail: "`/data/relationships/shirt/data/id` is missing",
+              meta: %{
+                "child" => "id"
+              },
+              source: %Alembic.Source{
+                pointer: "/data/relationships/shirt/data"
+              },
+              status: "422",
+              title: "Child missing"
+            }
+          ]
+        }
+      }
+
+  """
+  def from_json(json, error_template)
+
+  @spec from_json(Alembic.json_object, %Error{meta: Meta.t}) :: {:ok, t} | FromJson.error
+  def from_json(json, error_template = %Error{meta: meta}) when is_map(json) do
+    parent = %{error_template: error_template, json: json}
+
+    meta
+    |> child_options_list_from_meta
+    |> Stream.map(&Map.put(&1, :parent, parent))
+    |> Stream.map(&FromJson.from_parent_json_to_field_result/1)
+    |> FromJson.reduce({:ok, %__MODULE__{}})
+  end
+
+  # Alembic.json -- [Alembic.json_object]
+  @spec from_json(nil | true | false | list | float | integer | String.t, Error.t) :: FromJson.error
+  def from_json(_, error_template) do
+    {
+      :error,
+      %Document{
+        errors: [
+          Error.type(error_template, @human_type)
+        ]
+      }
+    }
+  end
+
+  ## Private Functions
+
+  @spec attributes_from_json(Alembic.json_object, Error.t) :: {:ok, Alembic.json_object}
+  defp attributes_from_json(attributes, _) when is_map(attributes), do: {:ok, attributes}
+
+  # the rest of Alembic.json
+  @spec attributes_from_json(nil | true | false | float | integer | String.t, Error.t) :: FromJson.error
+  defp attributes_from_json(_, error_template) do
+    {
+      :error,
+      %Document{
+        errors: [
+          Error.type(error_template, @attributes_human_type)
+        ]
+      }
+    }
+  end
+
+  # **MUST** be a function so it can capture reference to private `attributes_from_json/2`
+  @spec attributes_options() :: map
+  defp attributes_options do
+    put_in @attributes_options[:member][:from_json], &attributes_from_json/2
+  end
+
+  # Specializes the child_options_list based on `"action"` and `"sender"` in `meta`
+  #
+  # If the `"action"` is `:create` and the `"sender"` is `:client`, then `"id" is not required; otherwise,
+  # the `"id" is required.
+  @spec child_options_list_from_meta(map) :: [map, ...]
+  defp child_options_list_from_meta(meta) do
+    [attributes_options, id_options_from_meta(meta) | @child_options_list]
+  end
+
+  @spec id_options_from_meta(%{String.t => atom}) :: map
+
+  defp id_options_from_meta(%{"action" => :create, "sender" => :client}) do
+    put_in @id_options[:member][:required], false
+  end
+
+  # action is `FromJson @actions` -- [:create]
+  defp id_options_from_meta(%{"action" => action, "sender" => sender}) when (action in [:delete, :fetch, :update] and
+                                                                             sender in [:client, :server]) or
+                                                                            (action == :create and sender == :server) do
+    put_in @id_options[:member][:required], true
+  end
+
+  # Protocol Implementations
+
+  defimpl Poison.Encoder do
+    alias Alembic.Resource
+
+    @doc """
+    Only non-`nil` members are encoded
+
+        iex> Poison.encode(
+        ...>   %Alembic.Resource{
+        ...>     type: "post"
+        ...>   }
+        ...> )
+        {:ok, "{\\"type\\":\\"post\\"}"}
+
+    But, `type` is always required, so without it, an exception is raised.
+
+        iex> try do
+        ...>   Poison.encode(%Alembic.Resource{})
+        ...> rescue
+        ...>   e in FunctionClauseError -> e
+        ...> end
+        %FunctionClauseError{arity: 2, function: :encode, module: Poison.Encoder.Alembic.Resource}
+
+    """
+    def encode(resource = %Resource{type: type}, options) when not is_nil(type) do
+      # strip `nil` so that resources without id for create don't end up with `"id": null` after encoding
+      map = for {field, value} <- Map.from_struct(resource), value != nil, into: %{}, do: {field, value}
+
+      Poison.Encoder.Map.encode(map, options)
+    end
+  end
+end

--- a/lib/alembic/resource_identifier.ex
+++ b/lib/alembic/resource_identifier.ex
@@ -1,0 +1,252 @@
+defmodule Alembic.ResourceIdentifier do
+  @moduledoc """
+  A [JSON API Resource Identifier](http://jsonapi.org/format/#document-resource-identifier-objects).
+  """
+
+  alias Alembic.Document
+  alias Alembic.Error
+  alias Alembic.FromJson
+  alias Alembic.Meta
+
+  @behaviour FromJson
+
+  # Constants
+
+  @human_type "resource identifier"
+
+  @meta_options %{
+                  field: :meta,
+                  member: %{
+                    module: Meta,
+                    name: "meta"
+                  },
+                  parent: nil
+                }
+
+  # Struct
+
+  defstruct [:id, :meta, :type]
+
+  # Types
+
+  @typedoc """
+  > A "resource identifier object" is \\[an `%Alembic.ResourceIdentifier{}`\\] that identifies an
+  > individual resource.
+  >
+  > A "resource identifier object" **MUST** contain `type` and `id` members.
+  >
+  > A "resource identifier object" **MAY** also include a `meta` member, whose value is a
+  > \\[`Alembic.Meta.t`\\] that contains non-standard meta-information.
+  >
+  > -- <cite>
+  >  [JSON API - Document Structure - Resource Identifier
+  >   Object](http://jsonapi.org/format/#document-resource-identifier-objects)
+  > </cite>
+  """
+  @type t :: %__MODULE__{
+               id: String.t,
+               meta: Meta.t,
+               type: String.t
+             }
+
+  # Functions
+
+  @doc """
+  # Examples
+
+  ## A resource identifier is valid with `"id"` and `"type"`
+
+      iex> Alembic.ResourceIdentifier.from_json(
+      ...>   %{"id" => "1", "type" => "shirt"},
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/shirt/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {:ok, %Alembic.ResourceIdentifier{id: "1", type: "shirt"}}
+
+  ## A resource identifier can *optionally* have `"meta"`
+
+      iex> Alembic.ResourceIdentifier.from_json(
+      ...>   %{"id" => "1", "meta" => %{"copyright" => "2015"}, "type" => "shirt"},
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/shirt/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {:ok, %Alembic.ResourceIdentifier{id: "1", meta: %{"copyright" => "2015"}, type: "shirt"}}
+
+  ## A resource identifier **MUST** have an `"id"`
+
+      iex> Alembic.ResourceIdentifier.from_json(
+      ...>   %{"type" => "shirt"},
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/shirt/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data/relationships/shirt/data/id` is missing",
+              meta: %{
+                "child" => "id"
+              },
+              source: %Alembic.Source{
+                pointer: "/data/relationships/shirt/data"
+              },
+              status: "422",
+              title: "Child missing"
+            }
+          ]
+        }
+      }
+
+  ## A resource identifer **MUST** have a `"type"`
+
+      iex> Alembic.ResourceIdentifier.from_json(
+      ...>   %{"id" => "1"},
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/shirt/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data/relationships/shirt/data/type` is missing",
+              meta: %{
+                "child" => "type"
+              },
+              source: %Alembic.Source{
+                pointer: "/data/relationships/shirt/data"
+              },
+              status: "422",
+              title: "Child missing"
+            }
+          ]
+        }
+      }
+
+  ## A resource identifer missing both `"id"` and `"type"` will show both as missing
+
+      iex> Alembic.ResourceIdentifier.from_json(
+      ...>   %{},
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/shirt/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data/relationships/shirt/data/id` is missing",
+              meta: %{
+                "child" => "id"
+              },
+              source: %Alembic.Source{
+                pointer: "/data/relationships/shirt/data"
+              },
+              status: "422",
+              title: "Child missing"
+            },
+            %Alembic.Error{
+              detail: "`/data/relationships/shirt/data/type` is missing",
+              meta: %{
+                "child" => "type"
+              },
+              source: %Alembic.Source{
+                pointer: "/data/relationships/shirt/data"
+              },
+              status: "422",
+              title: "Child missing"
+            }
+          ]
+        }
+      }
+
+  ## A non-resource-identifier will be identified as such
+
+      iex> Alembic.ResourceIdentifier.from_json(
+      ...>   [],
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/shirt/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data/relationships/shirt/data` type is not resource identifier",
+              meta: %{
+                "type" => "resource identifier"
+              },
+              source: %Alembic.Source{
+                pointer: "/data/relationships/shirt/data"
+              },
+              status: "422",
+              title: "Type is wrong"
+            }
+          ]
+        }
+      }
+
+  """
+  def from_json(json, error_template)
+
+  @spec from_json(%{String.t => String.t | Alembic.json_object}, Error.t) :: {:ok, t} | FromJson.error
+  def from_json(json = %{}, error_template = %Error{}) do
+    parent = %{json: json, error_template: error_template}
+
+    id_result = FromJson.from_parent_json_to_field_result %{
+      field: :id,
+      member: %{
+        from_json: &FromJson.string_from_json/2,
+        name: "id",
+        required: true,
+      },
+      parent: parent
+    }
+
+    meta_result = FromJson.from_parent_json_to_field_result %{@meta_options | parent: parent}
+
+    type_result = FromJson.from_parent_json_to_field_result %{
+      field: :type,
+      member: %{
+        from_json: &FromJson.string_from_json/2,
+        name: "type",
+        required: true
+      },
+      parent: parent
+    }
+
+    FromJson.reduce([id_result, meta_result, type_result], {:ok, %__MODULE__{}})
+  end
+
+  # Alembic.json -- [Alembic.json_object]
+  @spec from_json(nil | true | false | list | float | integer | String.t, Error.t) :: FromJson.error
+  def from_json(_, error_template) do
+    {
+      :error,
+      %Document{
+        errors: [
+          Error.type(error_template, @human_type)
+        ]
+      }
+    }
+  end
+end

--- a/lib/alembic/resource_linkage.ex
+++ b/lib/alembic/resource_linkage.ex
@@ -1,0 +1,171 @@
+defmodule Alembic.ResourceLinkage do
+  @moduledoc """
+  > Resource linkage in a compound document allows a client to link together all of the included resource objects
+  > without having to `GET` any URLs via links.
+  >
+  > Resource linkage **MUST** be represented as one of the following:
+
+  > * `null` for empty to-one relationships.
+  > * an empty array (`[]`) for empty to-many relationships.
+  > * a single resource identifier object for non-empty to-one relationships.
+  > * an array of resource identifier objects for non-empty to-many relationships.
+  >
+  > -- <cite>
+  >  [JSON API - Document Structure - Resource Objects -
+  >   Resource Linkage](http://jsonapi.org/format/#document-resource-object-linkage)
+  > </cite>
+  """
+
+  alias Alembic.Document
+  alias Alembic.Error
+  alias Alembic.FromJson
+  alias Alembic.ResourceIdentifier
+
+  @behaviour FromJson
+
+  # Constants
+
+  @human_type "resource linkage"
+
+  # Functions
+
+  @doc """
+  Converts a resource linkage to one or more `Alembic.ResoureIdentifier.t`.
+
+  ## To-one
+
+  A to-one resource linkage, when present, will be a single `Alembic.ResourceIdentifier.t`
+
+      iex> Alembic.ResourceLinkage.from_json(
+      ...>   %{
+      ...>     "id" => "1",
+      ...>     "type" => "author"
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/author/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Alembic.ResourceIdentifier{
+          id: "1",
+          type: "author"
+        }
+      }
+
+  An empty to-one resource linkage can be signified with `nil`, which would have been `null` in the original JSON.
+
+      iex> Alembic.ResourceLinkage.from_json(
+      ...>   nil,
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/author/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {:ok, nil}
+
+  ## To-many
+
+  A to-many resource linkage, when preent, will be a list of `Alembic.ResourceIdentifier.t`
+
+      iex> Alembic.ResourceLinkage.from_json(
+      ...>   [
+      ...>     %{
+      ...>       "id" => "1",
+      ...>       "type" => "comment"
+      ...>     }
+      ...>   ],
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/comments/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        [
+          %Alembic.ResourceIdentifier{
+            id: "1",
+            type: "comment"
+          }
+        ]
+      }
+
+  An empty to-many resource linkage can be signified with `[]`.
+
+      iex> Alembic.ResourceLinkage.from_json(
+      ...>   [],
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/comments/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {:ok, []}
+
+  ## Invalid
+
+  If the `json` isn't any of the above, valid formats, then a type error will be returned
+
+      iex> Alembic.ResourceLinkage.from_json(
+      ...>   "that resource over there",
+      ...>   %Alembic.Error{
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/resource/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data/relationships/resource/data` type is not resource linkage",
+              meta: %{
+                "type" => "resource linkage"
+              },
+              source: %Alembic.Source{
+                pointer: "/data/relationships/resource/data"
+              },
+              status: "422",
+              title: "Type is wrong"
+            }
+          ]
+        }
+      }
+
+  """
+  def from_json(json, error_template)
+
+  @spec from_json(nil, Error.t) :: {:ok, nil}
+  def from_json(nil, _), do: {:ok, nil}
+
+  @spec from_json([], Error.t) :: {:ok, []}
+  def from_json([], _), do: {:ok, []}
+
+  @spec from_json(Alembic.json_object, Error.t) :: {:ok, ResourceIdentifier.t} | FromJson.error
+  def from_json(resource_identifier_json, error_template) when is_map(resource_identifier_json) do
+    ResourceIdentifier.from_json(resource_identifier_json, error_template)
+  end
+
+  @spec from_json([Alembic.json_object, ...], Error.t) :: {:ok, [ResourceIdentifier.t]} | FromJson.error
+  def from_json(resource_identifiers_json, error_template) when is_list(resource_identifiers_json) do
+    FromJson.from_json_array(resource_identifiers_json, error_template, ResourceIdentifier)
+  end
+
+  # Alembic.json -- [nil, [], Alembic.json_object, [Alembic.json_object]]
+  @spec from_json(true | false | float | integer, Error.t) :: FromJson.error
+  def from_json(_, error_template) do
+    {
+      :error,
+      %Document{
+        errors: [
+          Error.type(error_template, @human_type)
+        ]
+      }
+    }
+  end
+end

--- a/lib/alembic/resource_linkage.ex
+++ b/lib/alembic/resource_linkage.ex
@@ -19,6 +19,7 @@ defmodule Alembic.ResourceLinkage do
   alias Alembic.Document
   alias Alembic.Error
   alias Alembic.FromJson
+  alias Alembic.Resource
   alias Alembic.ResourceIdentifier
 
   @behaviour FromJson
@@ -34,7 +35,84 @@ defmodule Alembic.ResourceLinkage do
 
   ## To-one
 
-  A to-one resource linkage, when present, will be a single `Alembic.ResourceIdentifier.t`
+  A to-one resource linkage, when present, can be a single `Alembic.Resource.t` or
+  `Alembic.ResourceIdentifier.t`
+
+  A JSON object is assumed to be an resource object if it has `"attributes"`
+
+      iex> Alembic.ResourceLinkage.from_json(
+      ...>   %{
+      ...>     "attributes" => %{
+      ...>       "name" => "Alice"
+      ...>     },
+      ...>     "id" => "1",
+      ...>     "type" => "author"
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data/relationships/author/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Alembic.Resource{
+          attributes: %{
+            "name" => "Alice"
+          },
+          id: "1",
+          type: "author"
+        }
+      }
+
+  Or if the JSON object has `"relationships"`
+
+      iex> Alembic.ResourceLinkage.from_json(
+      ...>   %{
+      ...>     "id" => "1",
+      ...>     "relationships" => %{
+      ...>       "author" => %{
+      ...>         "data" => %{
+      ...>           "id" => "1",
+      ...>           "type" => "author"
+      ...>         }
+      ...>       }
+      ...>     },
+      ...>     "type" => "post"
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Alembic.Resource{
+          id: "1",
+          relationships: %{
+            "author" => %Alembic.Relationship{
+              data: %Alembic.ResourceIdentifier{
+                id: "1",
+                meta: nil,
+                type: "author"
+              }
+            }
+          },
+          type: "post"
+        }
+      }
+
+  If neither `"attributes"` nor `"relationships"` is present, then JSON object is assumed to be an
+  `Alembic.ResourceIdentifier.t`.
 
       iex> Alembic.ResourceLinkage.from_json(
       ...>   %{
@@ -55,6 +133,7 @@ defmodule Alembic.ResourceLinkage do
         }
       }
 
+
   An empty to-one resource linkage can be signified with `nil`, which would have been `null` in the original JSON.
 
       iex> Alembic.ResourceLinkage.from_json(
@@ -69,18 +148,74 @@ defmodule Alembic.ResourceLinkage do
 
   ## To-many
 
-  A to-many resource linkage, when preent, will be a list of `Alembic.ResourceIdentifier.t`
+  A to-many resource linkage, when present, can be a list of `Alembic.Resource.t`.
+
+      iex> Alembic.ResourceLinkage.from_json(
+      ...>   [
+      ...>     %{
+      ...>       "attributes" => %{
+      ...>         "text" => "First Post!"
+      ...>       },
+      ...>       "id" => "1",
+      ...>       "relationships" => %{
+      ...>         "comments" => %{
+      ...>           "data" => [
+      ...>             %{
+      ...>               "id" => "1",
+      ...>               "type" => "comment"
+      ...>             }
+      ...>           ]
+      ...>         }
+      ...>       },
+      ...>       "type" => "post"
+      ...>     }
+      ...>   ],
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        [
+          %Alembic.Resource{
+            attributes: %{
+              "text" => "First Post!"
+            },
+            id: "1",
+            links: nil,
+            relationships: %{
+              "comments" => %Alembic.Relationship{
+                data: [
+                  %Alembic.ResourceIdentifier{
+                    id: "1",
+                    type: "comment"
+                  }
+                ]
+              }
+            },
+            type: "post"
+          }
+        ]
+      }
+
+  Or a list of `Alembic.ResourceIdentifier.t`.
 
       iex> Alembic.ResourceLinkage.from_json(
       ...>   [
       ...>     %{
       ...>       "id" => "1",
-      ...>       "type" => "comment"
+      ...>       "type" => "post"
       ...>     }
       ...>   ],
       ...>   %Alembic.Error{
       ...>     source: %Alembic.Source{
-      ...>       pointer: "/data/relationships/comments/data"
+      ...>       pointer: "/data"
       ...>     }
       ...>   }
       ...> )
@@ -89,9 +224,54 @@ defmodule Alembic.ResourceLinkage do
         [
           %Alembic.ResourceIdentifier{
             id: "1",
-            type: "comment"
+            type: "post"
           }
         ]
+      }
+
+  A mix of resources and resource identifiers is an error
+
+      iex> Alembic.ResourceLinkage.from_json(
+      ...>   [
+      ...>     %{
+      ...>       "attributes" => %{
+      ...>         "text" => "First Post!"
+      ...>       },
+      ...>       "id" => "1",
+      ...>       "type" => "post"
+      ...>     },
+      ...>     %{
+      ...>       "id" => "2",
+      ...>       "type" => "post"
+      ...>     }
+      ...>   ],
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: "/data"
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :error,
+        %Alembic.Document{
+          errors: [
+            %Alembic.Error{
+              detail: "`/data` type is not resource linkage",
+              meta: %{
+                "type" => "resource linkage"
+              },
+              source: %Alembic.Source{
+                pointer: "/data"
+              },
+              status: "422",
+              title: "Type is wrong"
+            }
+          ]
+        }
       }
 
   An empty to-many resource linkage can be signified with `[]`.
@@ -146,19 +326,55 @@ defmodule Alembic.ResourceLinkage do
   @spec from_json([], Error.t) :: {:ok, []}
   def from_json([], _), do: {:ok, []}
 
-  @spec from_json(Alembic.json_object, Error.t) :: {:ok, ResourceIdentifier.t} | FromJson.error
-  def from_json(resource_identifier_json, error_template) when is_map(resource_identifier_json) do
-    ResourceIdentifier.from_json(resource_identifier_json, error_template)
+  @spec from_json(Alembic.json_object, Error.t) :: {:ok, Resource.t | ResourceIdentifier.t} | FromJson.error
+  def from_json(json_object, error_template) when is_map(json_object) do
+    resource_or_resource_identifier_from_json(json_object, error_template)
   end
 
-  @spec from_json([Alembic.json_object, ...], Error.t) :: {:ok, [ResourceIdentifier.t]} | FromJson.error
-  def from_json(resource_identifiers_json, error_template) when is_list(resource_identifiers_json) do
-    FromJson.from_json_array(resource_identifiers_json, error_template, ResourceIdentifier)
+  @spec from_json([Alembic.json_object, ...], Error.t) :: {:ok, [Resource.t | ResourceIdentifier.t]} | FromJson.error
+  def from_json(json_array, error_template) when is_list(json_array) do
+    json_array
+    |> FromJson.from_json_array(error_template, &resource_or_resource_identifier_from_json/2)
+    |> validate_consistent_types(error_template)
   end
 
   # Alembic.json -- [nil, [], Alembic.json_object, [Alembic.json_object]]
   @spec from_json(true | false | float | integer, Error.t) :: FromJson.error
-  def from_json(_, error_template) do
+  def from_json(_, error_template), do: type_error(error_template)
+
+  ## Private Functions
+
+  defp consistent_types?(list) when is_list(list) do
+    list
+    |> Enum.into(MapSet.new, fn element ->
+          element.__struct__
+       end)
+    |> MapSet.size == 1
+  end
+
+  defp resource_or_resource_identifier_from_json(json = %{"attributes" => _}, error_template) do
+    Resource.from_json(json, error_template)
+  end
+
+  defp resource_or_resource_identifier_from_json(json = %{"relationships" => _}, error_template) do
+    Resource.from_json(json, error_template)
+  end
+
+  defp resource_or_resource_identifier_from_json(json, error_template) do
+    ResourceIdentifier.from_json(json, error_template)
+  end
+
+  defp validate_consistent_types(collectable_result = {:error, _}, _), do: collectable_result
+
+  defp validate_consistent_types(collectable_result = {:ok, list}, error_template) when is_list(list) do
+    if consistent_types?(list) do
+      collectable_result
+    else
+      type_error(error_template)
+    end
+  end
+
+  defp type_error(error_template) do
     {
       :error,
       %Document{

--- a/mix.exs
+++ b/mix.exs
@@ -1,12 +1,22 @@
 defmodule Alembic.Mixfile do
   use Mix.Project
 
+  # Functions
+
+  # Configuration for the OTP application
+  #
+  # Type "mix help compile.app" for more information
+  def application do
+    [applications: [:logger, :poison]]
+  end
+
   def project do
     [
       app: :alembic,
       build_embedded: Mix.env == :prod,
       deps: deps,
       elixir: "~> 1.2",
+      elixirc_paths: elixirc_paths(Mix.env),
       name: "Alembic",
       source_url: "https://github.com/C-S-D/alembic",
       start_permanent: Mix.env == :prod,
@@ -15,12 +25,7 @@ defmodule Alembic.Mixfile do
     ]
   end
 
-  # Configuration for the OTP application
-  #
-  # Type "mix help compile.app" for more information
-  def application do
-    [applications: [:logger, :poison]]
-  end
+  ## Private Functions
 
   # Dependencies can be Hex packages:
   #
@@ -51,4 +56,7 @@ defmodule Alembic.Mixfile do
       {:poison, "~> 2.1"}
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_),     do: ["lib"]
 end

--- a/test/alembic/document_test.exs
+++ b/test/alembic/document_test.exs
@@ -8,21 +8,1389 @@ defmodule Alembic.DocumentTest do
   alias Alembic.Document
   alias Alembic.Error
   alias Alembic.FromJsonCase
+  alias Alembic.Relationship
+  alias Alembic.Resource
+  alias Alembic.ResourceIdentifier
   alias Alembic.Source
+
+  # Constants
+
+  @error_template %Error{
+    source: %Source{
+      pointer: ""
+    }
+  }
+
+  # Tests
 
   doctest Document
 
-  test "Poison.encode -> Poison.decode -> from_json/2 is idempotent for errors document" do
-    error_template = %Error{
-      source: %Source{
-        pointer: ""
+  # See http://jsonapi.org/format/#document-compound-documents"
+
+  test "complete example with multiple included relationships" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "data": [{
+        "type": "articles",
+        "id": "1",
+        "attributes": {
+          "title": "JSON API paints my bikeshed!"
+        },
+        "links": {
+          "self": "http://example.com/articles/1"
+        },
+        "relationships": {
+          "author": {
+            "links": {
+              "self": "http://example.com/articles/1/relationships/author",
+              "related": "http://example.com/articles/1/author"
+            },
+            "data": {"type": "people", "id": "9"}
+          },
+          "comments": {
+            "links": {
+              "self": "http://example.com/articles/1/relationships/comments",
+              "related": "http://example.com/articles/1/comments"
+            },
+            "data": [
+              {"type": "comments", "id": "5"},
+              {"type": "comments", "id": "12"}
+            ]
+          }
+        }
+      }],
+      "included": [{
+        "type": "people",
+        "id": "9",
+        "attributes": {
+          "first-name": "Dan",
+          "last-name": "Gebhardt",
+          "twitter": "dgeb"
+        },
+        "links": {
+          "self": "http://example.com/people/9"
+        }
+      }, {
+        "type": "comments",
+        "id": "5",
+        "attributes": {
+          "body": "First!"
+        },
+        "relationships": {
+          "author": {
+            "data": {"type": "people", "id": "2"}
+          }
+        },
+        "links": {
+          "self": "http://example.com/comments/5"
+        }
+      }, {
+        "type": "comments",
+        "id": "12",
+        "attributes": {
+          "body": "I like XML better"
+        },
+        "relationships": {
+          "author": {
+            "data": {"type": "people", "id": "9"}
+          }
+        },
+        "links": {
+          "self": "http://example.com/comments/12"
+        }
+      }]
+    }
+    """
+    error_template = %Error{ @error_template | meta: %{ "action" => :fetch, "sender" => :server } }
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: [
+        %Resource{
+          attributes: %{
+            "title" => "JSON API paints my bikeshed!"
+          },
+          id: "1",
+          links: %{
+            "self" => "http://example.com/articles/1"
+          },
+          relationships: %{
+            "author" => %Relationship{
+              data: %ResourceIdentifier{
+                id: "9",
+                type: "people"
+              },
+              links: %{
+                "related" => "http://example.com/articles/1/author",
+                "self" => "http://example.com/articles/1/relationships/author"
+              }
+            },
+            "comments" => %Relationship{
+              data: [
+                %ResourceIdentifier{
+                  id: "5",
+                  type: "comments"
+                },
+                %ResourceIdentifier{
+                  id: "12",
+                  type: "comments"
+                }
+              ],
+              links: %{
+                "related" => "http://example.com/articles/1/comments",
+                "self" => "http://example.com/articles/1/relationships/comments"
+              }
+            }
+          },
+          type: "articles"
+        }
+      ],
+      included: [
+        %Resource{
+          attributes: %{
+            "first-name" => "Dan",
+            "last-name" => "Gebhardt",
+            "twitter" => "dgeb"
+          },
+          id: "9",
+          links: %{
+            "self" => "http://example.com/people/9"
+          },
+          type: "people"
+        },
+        %Resource{
+          attributes: %{
+            "body" => "First!"
+          },
+          id: "5",
+          links: %{
+            "self" => "http://example.com/comments/5"
+          },
+          relationships: %{
+            "author" => %Relationship{
+              data: %ResourceIdentifier{
+                id: "2",
+                type: "people"
+              }
+            }
+          },
+          type: "comments"
+        },
+        %Resource{
+          attributes: %{
+            "body" => "I like XML better"
+          },
+          id: "12",
+          links: %{
+            "self" => "http://example.com/comments/12"
+          },
+          relationships: %{
+            "author" => %Relationship{
+              data: %ResourceIdentifier{
+                id: "9",
+                type: "people"
+              }
+            }
+          },
+          type: "comments"
+        }
+      ]
+    }
+    assert_idempotent document, error_template
+  end
+
+  ## See http://jsonapi.org/format/#fetching-resources-responses-200
+
+  test "fetching resources responses 200 collection of articles" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "links": {
+        "self": "http://example.com/articles"
+      },
+      "data": [{
+        "type": "articles",
+        "id": "1",
+        "attributes": {
+          "title": "JSON API paints my bikeshed!"
+        }
+      }, {
+        "type": "articles",
+        "id": "2",
+        "attributes": {
+          "title": "Rails is Omakase"
+        }
+      }]
+    }
+    """
+    error_template = %Error{ @error_template | meta: %{ "action" => :fetch, "sender" => :server } }
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: [
+        %Resource{
+          attributes: %{
+            "title" => "JSON API paints my bikeshed!"
+          },
+          id: "1",
+          type: "articles"
+        },
+        %Resource{
+          attributes: %{
+            "title" => "Rails is Omakase"
+          },
+          id: "2",
+          type: "articles"
+        }
+      ],
+      links: %{
+        "self" => "http://example.com/articles"
       }
     }
+    assert_idempotent document, error_template
+  end
 
-    {:error, response} = Document.from_json(%{}, error_template)
+  test "fetching resources responses 200 empty collection" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "links": {
+        "self": "http://example.com/articles"
+      },
+      "data": []
+    }
+    """
+    error_template = %Error{ @error_template | meta: %{ "action" => :fetch, "sender" => :server } }
+    {:ok, document} = Document.from_json(decoded, error_template)
 
+    assert document == %Document{
+      data: [],
+      links: %{
+        "self" => "http://example.com/articles"
+      }
+    }
+    assert_idempotent document, error_template
+  end
+
+  test "fetching resource response 200 individual" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "links": {
+        "self": "http://example.com/articles/1"
+      },
+      "data": {
+        "type": "articles",
+        "id": "1",
+        "attributes": {
+          "title": "JSON API paints my bikeshed!"
+        },
+        "relationships": {
+          "author": {
+            "links": {
+              "related": "http://example.com/articles/1/author"
+            }
+          }
+        }
+      }
+    }
+    """
+    error_template = %Error{ @error_template | meta: %{ "action" => :fetch, "sender" => :server } }
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: %Resource{
+        attributes: %{
+          "title" => "JSON API paints my bikeshed!"
+        },
+        id: "1",
+        relationships: %{
+          "author" => %Relationship{
+            links: %{
+              "related" => "http://example.com/articles/1/author"
+            }
+          }
+        },
+        type: "articles"
+      },
+      links: %{
+        "self" => "http://example.com/articles/1"
+      }
+    }
+    assert_idempotent document, error_template
+  end
+
+  test "fetching resource response 200 empty" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "links": {
+        "self": "http://example.com/articles/1/author"
+      },
+      "data": null
+    }
+    """
+    error_template = %Error{ @error_template | meta: %{ "action" => :fetch, "sender" => :server } }
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: nil,
+      links: %{
+        "self" => "http://example.com/articles/1/author"
+      }
+    }
+    assert_idempotent document, error_template
+  end
+
+  ## See http://jsonapi.org/format/#fetching-relationships-responses-200
+
+  test "fetching present to-one relationship" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "links": {
+        "self": "/articles/1/relationships/author",
+        "related": "/articles/1/author"
+      },
+      "data": {
+        "type": "people",
+        "id": "12"
+      }
+    }
+    """
+    error_template = %Error{ @error_template | meta: %{ "action" => :fetch, "sender" => :server } }
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: %ResourceIdentifier{
+        id: "12",
+        type: "people"
+      },
+      links: %{
+        "related" => "/articles/1/author",
+        "self" => "/articles/1/relationships/author"
+      }
+    }
+    assert_idempotent document, error_template
+  end
+
+  test "fetching empty to-one relationship" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "links": {
+        "self": "/articles/1/relationships/author",
+        "related": "/articles/1/author"
+      },
+      "data": null
+    }
+    """
+    error_template = %Error{ @error_template | meta: %{ "action" => :fetch, "sender" => :server } }
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: nil,
+      links: %{
+        "related" => "/articles/1/author",
+        "self" => "/articles/1/relationships/author"
+      }
+    }
+    assert_idempotent document, error_template
+  end
+
+  test "fetching present to-many relationship" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "links": {
+        "self": "/articles/1/relationships/tags",
+        "related": "/articles/1/tags"
+      },
+      "data": [
+        {"type": "tags", "id": "2"},
+        {"type": "tags", "id": "3"}
+      ]
+    }
+    """
+    error_template = %Error{ @error_template | meta: %{ "action" => :fetch, "sender" => :server } }
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document ==  %Document{
+      data: [
+        %ResourceIdentifier{
+          id: "2",
+          type: "tags"
+        },
+        %ResourceIdentifier{
+          id: "3",
+          type: "tags"
+        }
+      ],
+      links: %{
+        "related" => "/articles/1/tags",
+        "self" => "/articles/1/relationships/tags"
+      }
+    }
+    assert_idempotent document, error_template
+  end
+
+  test "fetching empty to-many relationship" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "links": {
+        "self": "/articles/1/relationships/tags",
+        "related": "/articles/1/tags"
+      },
+      "data": []
+    }
+    """
+    error_template = %Error{ @error_template | meta: %{ "action" => :fetch, "sender" => :server } }
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: [],
+      links: %{
+        "related" => "/articles/1/tags",
+        "self" => "/articles/1/relationships/tags"
+      }
+    }
+    assert_idempotent document, error_template
+  end
+
+  ## See http://jsonapi.org/format/#crud-creating
+
+  test "creating resource" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "data": {
+        "type": "photos",
+        "attributes": {
+          "title": "Ember Hamster",
+          "src": "http://example.com/images/productivity.png"
+        },
+        "relationships": {
+          "photographer": {
+            "data": {"type": "people", "id": "9"}
+          }
+        }
+      }
+    }
+    """
+    error_template = %Error{ @error_template | meta: %{ "action" => :create, "sender" => :client } }
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: %Resource{
+        attributes: %{
+          "src" => "http://example.com/images/productivity.png",
+          "title" => "Ember Hamster"
+        },
+        relationships: %{
+          "photographer" => %Relationship{
+            data: %ResourceIdentifier{
+              id: "9",
+              type: "people"
+            }
+          }
+        },
+        type: "photos"
+      }
+    }
+    assert_idempotent document, error_template
+  end
+
+  ## See http://jsonapi.org/format/#crud-creating-client-ids
+
+  test "client generate ids" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "data": {
+        "type": "photos",
+        "id": "550e8400-e29b-41d4-a716-446655440000",
+        "attributes": {
+          "title": "Ember Hamster",
+          "src": "http://example.com/images/productivity.png"
+        }
+      }
+    }
+    """
+    error_template = %Error{ @error_template | meta: %{ "action" => :create, "sender" => :client } }
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: %Resource{
+        attributes: %{
+          "src" => "http://example.com/images/productivity.png",
+          "title" => "Ember Hamster"},
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        type: "photos"
+      }
+    }
+    assert_idempotent document, error_template
+  end
+
+  ## See http://jsonapi.org/format/#crud-creating-responses-201
+
+  test "created" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "data": {
+        "type": "photos",
+        "id": "550e8400-e29b-41d4-a716-446655440000",
+        "attributes": {
+          "title": "Ember Hamster",
+          "src": "http://example.com/images/productivity.png"
+        },
+        "links": {
+          "self": "http://example.com/photos/550e8400-e29b-41d4-a716-446655440000"
+        }
+      }
+    }
+    """
+    error_template = %Error{ @error_template | meta: %{ "action" => :create, "sender" => :server } }
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: %Resource{
+        attributes: %{
+          "src" => "http://example.com/images/productivity.png",
+          "title" => "Ember Hamster"
+        },
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        links: %{
+          "self" => "http://example.com/photos/550e8400-e29b-41d4-a716-446655440000"
+        },
+        type: "photos"
+      }
+    }
+    assert_idempotent document, error_template
+  end
+
+  ## See http://jsonapi.org/format/#crud-updating
+
+  test "updating single resource" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "data": {
+        "type": "articles",
+        "id": "1",
+        "attributes": {
+          "title": "To TDD or Not"
+        }
+      }
+    }
+    """
+    error_template = %Error{ @error_template | meta: %{ "action" => :update, "sender" => :client } }
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: %Resource{
+        attributes: %{
+          "title" => "To TDD or Not"
+        },
+        id: "1",
+        type: "articles"
+      }
+    }
+    assert_idempotent document, error_template
+  end
+
+  ## See http://jsonapi.org/format/#crud-updating-resource-attributes
+
+  test "updating a resources attributes" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "data": {
+        "type": "articles",
+        "id": "1",
+        "attributes": {
+          "title": "To TDD or Not",
+          "text": "TLDR; It's complicated... but check your test coverage regardless."
+        }
+      }
+    }
+    """
+    error_template = %Error{ @error_template | meta: %{ "action" => :update, "sender" => :client } }
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: %Resource{
+        attributes: %{
+          "text" => "TLDR; It's complicated... but check your test coverage regardless.",
+          "title" => "To TDD or Not"
+        },
+        id: "1",
+        type: "articles"
+      }
+    }
+    assert_idempotent document, error_template
+  end
+
+  ## See http://jsonapi.org/format/#crud-updating-resource-relationships
+
+  test "updating a resource's to-one relationship" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "data": {
+        "type": "articles",
+        "id": "1",
+        "relationships": {
+          "author": {
+            "data": {"type": "people", "id": "1"}
+          }
+        }
+      }
+    }
+    """
+    error_template = %Error{@error_template | meta: %{"action" => :update, "sender" => :client}}
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: %Resource{
+        id: "1",
+        relationships: %{
+          "author" => %Relationship{
+            data: %ResourceIdentifier{
+              id: "1",
+              type: "people"
+            }
+          }
+        },
+        type: "articles"
+      }
+    }
+    assert_idempotent document, error_template
+  end
+
+  test "updating a resource's to-many relationship" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "data": {
+        "type": "articles",
+        "id": "1",
+        "relationships": {
+          "tags": {
+            "data": [
+              {"type": "tags", "id": "2"},
+              {"type": "tags", "id": "3"}
+            ]
+          }
+        }
+      }
+    }
+    """
+    error_template = %Error{ @error_template | meta: %{ "action" => :update, "sender" => :client } }
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: %Resource{
+        id: "1",
+        relationships: %{
+          "tags" => %Relationship{
+            data: [
+              %ResourceIdentifier{
+                id: "2",
+                type: "tags"
+              },
+              %ResourceIdentifier{
+                id: "3",
+                type: "tags"
+              }
+            ]
+          }
+        },
+        type: "articles"
+      }
+    }
+    assert_idempotent document, error_template
+  end
+
+  ## See http://jsonapi.org/format/#crud-updating-to-one-relationships
+
+  test "updating to-one relationship" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "data": {"type": "people", "id": "12"}
+    }
+    """
+    error_template = %Error{@error_template | meta: %{"action" => :update, "sender" => :client}}
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: %ResourceIdentifier{
+        id: "12",
+        type: "people"
+      }
+    }
+    assert_idempotent document, error_template
+  end
+
+  test "clearing to-one relationship" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "data": null
+    }
+    """
+    error_template = %Error{ @error_template | meta: %{ "action" => :update, "sender" => :client } }
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: nil
+    }
+    assert_idempotent document, error_template
+  end
+
+  ## See http://jsonapi.org/format/#crud-updating-to-many-relationships
+
+  test "updating to-many relationship" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "data": [
+        {"type": "tags", "id": "2"},
+        {"type": "tags", "id": "3"}
+      ]
+    }
+    """
+    error_template = %Error{ @error_template | meta: %{ "action" => :update, "sender" => :client } }
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: [
+        %ResourceIdentifier{
+          id: "2",
+          type: "tags"
+        },
+        %ResourceIdentifier{
+          id: "3",
+          type: "tags"
+        }
+      ]
+    }
+    assert_idempotent document, error_template
+  end
+
+  test "clearing to-many relationship" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "data": []
+    }
+    """
+    error_template = %Error{ @error_template | meta: %{ "action" => :update, "sender" => :client } }
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: []
+    }
+    assert_idempotent document, error_template
+  end
+
+  test "posting to-many relationship" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "data": [
+        {"type": "comments", "id": "123"}
+      ]
+    }
+    """
+    error_template = %Error{@error_template | meta: %{"action" => :update, "sender" => :client}}
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: [
+        %ResourceIdentifier{
+          id: "123",
+          type: "comments"
+        }
+      ]
+    }
+    assert_idempotent document, error_template
+  end
+
+  test "deleting to-many relationship" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "data": [
+        {"type": "comments", "id": "12"},
+        {"type": "comments", "id": "13"}
+      ]
+    }
+    """
+    error_template = %Error{@error_template | meta: %{"action" => :delete, "sender" => :client}}
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: [
+        %ResourceIdentifier{
+          id: "12",
+          type: "comments"
+        },
+        %ResourceIdentifier{
+          id: "13",
+          type: "comments"
+        }
+      ]
+    }
+    assert_idempotent document, error_template
+  end
+
+  ## See http://jsonapi.org/recommendations/#asynchronous-processing
+
+  test "asynchronous processing" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "data": {
+        "type": "queue-jobs",
+        "id": "5234",
+        "attributes": {
+          "status": "Pending request, waiting other process"
+        },
+        "links": {
+          "self": "/photos/queue-jobs/5234"
+        }
+      }
+    }
+    """
+    error_template = %Error{@error_template | meta: %{"action" => :create, "sender" => :server}}
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: %Resource{
+        attributes: %{
+          "status" => "Pending request, waiting other process"
+        },
+        id: "5234",
+        links: %{
+          "self" => "/photos/queue-jobs/5234"
+        },
+        type: "queue-jobs"
+      }
+    }
+    assert_idempotent document, error_template
+  end
+
+  ## See http://jsonapi.org/examples/#sparse-fieldsets
+
+  test "sparse fieldset with include" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "data": [{
+        "type": "articles",
+        "id": "1",
+        "attributes": {
+          "title": "JSON API paints my bikeshed!",
+          "body": "The shortest article. Ever.",
+          "created": "2015-05-22T14:56:29.000Z",
+          "updated": "2015-05-22T14:56:28.000Z"
+        },
+        "relationships": {
+          "author": {
+            "data": {"id": "42", "type": "people"}
+          }
+        }
+      }],
+      "included": [
+        {
+          "type": "people",
+          "id": "42",
+          "attributes": {
+            "name": "John",
+            "age": 80,
+            "gender": "male"
+          }
+        }
+      ]
+    }
+    """
+    error_template = %Error{ @error_template | meta: %{ "action" => :fetch, "sender" => :server } }
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: [
+        %Resource{
+          attributes: %{
+            "body" => "The shortest article. Ever.",
+            "created" => "2015-05-22T14:56:29.000Z",
+            "title" => "JSON API paints my bikeshed!",
+            "updated" => "2015-05-22T14:56:28.000Z"
+          },
+          id: "1",
+          relationships: %{
+            "author" => %Relationship{
+              data: %ResourceIdentifier{
+                id: "42",
+                type: "people"
+              }
+            }
+          },
+          type: "articles"
+        }
+      ],
+      included: [
+        %Resource{
+          attributes: %{
+            "age" => 80,
+            "gender" => "male",
+            "name" => "John"
+          },
+          id: "42",
+          type: "people"
+        }
+      ]
+    }
+    assert_idempotent document, error_template
+  end
+
+  test "sparse fieldset with include and fields" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "data": [{
+        "type": "articles",
+        "id": "1",
+        "attributes": {
+          "title": "JSON API paints my bikeshed!",
+          "body": "The shortest article. Ever."
+        },
+        "relationships": {
+          "author": {
+            "data": {"id": "42", "type": "people"}
+          }
+        }
+      }],
+      "included": [
+        {
+          "type": "people",
+          "id": "42",
+          "attributes": {
+            "name": "John"
+          }
+        }
+      ]
+    }
+    """
+    error_template = %Error{ @error_template | meta: %{ "action" => :fetch, "sender" => :server } }
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: [
+        %Resource{
+          attributes: %{
+            "body" => "The shortest article. Ever.",
+            "title" => "JSON API paints my bikeshed!"
+          },
+          id: "1",
+          relationships: %{
+            "author" => %Relationship{
+              data: %ResourceIdentifier{
+                id: "42",
+                type: "people"
+              }
+            }
+          },
+          type: "articles"
+        }
+      ],
+      included: [
+        %Resource{
+          attributes: %{
+            "name" => "John"
+          },
+          id: "42",
+          type: "people"
+        }
+      ]
+    }
+    assert_idempotent document, error_template
+  end
+
+  test "sparse fields with fields" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "data": [{
+        "type": "articles",
+        "id": "1",
+        "attributes": {
+          "title": "JSON API paints my bikeshed!",
+          "body": "The shortest article. Ever."
+        }
+      }],
+      "included": [
+        {
+          "type": "people",
+          "id": "42",
+          "attributes": {
+            "name": "John"
+          }
+        }
+      ]
+    }
+    """
+    error_template = %Error{ @error_template | meta: %{ "action" => :fetch, "sender" => :server } }
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: [
+        %Resource{
+          attributes: %{
+            "body" => "The shortest article. Ever.",
+            "title" => "JSON API paints my bikeshed!"
+          },
+          id: "1",
+          type: "articles"
+        }
+      ],
+      included: [
+        %Resource{
+          attributes: %{
+            "name" => "John"
+          },
+          id: "42",
+          type: "people"
+        }
+      ]
+    }
+    assert_idempotent document, error_template
+  end
+
+  ## See http://jsonapi.org/examples/#pagination
+
+  test "pagination links" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "meta": {
+        "total-pages": 13
+      },
+      "data": [
+        {
+          "type": "articles",
+          "id": "3",
+          "attributes": {
+            "title": "JSON API paints my bikeshed!",
+            "body": "The shortest article. Ever.",
+            "created": "2015-05-22T14:56:29.000Z",
+            "updated": "2015-05-22T14:56:28.000Z"
+          }
+        }
+      ],
+      "links": {
+        "self": "http://example.com/articles?page[number]=3&page[size]=1",
+        "first": "http://example.com/articles?page[number]=1&page[size]=1",
+        "prev": "http://example.com/articles?page[number]=2&page[size]=1",
+        "next": "http://example.com/articles?page[number]=4&page[size]=1",
+        "last": "http://example.com/articles?page[number]=13&page[size]=1"
+      }
+    }
+    """
+    error_template = %Error{ @error_template | meta: %{ "action" => :fetch, "sender" => :server } }
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      data: [
+        %Resource{
+          attributes: %{
+            "body" => "The shortest article. Ever.",
+            "created" => "2015-05-22T14:56:29.000Z",
+            "title" => "JSON API paints my bikeshed!",
+            "updated" => "2015-05-22T14:56:28.000Z"
+          },
+          id: "3",
+          type: "articles"
+        }
+      ],
+      links: %{
+        "first" => "http://example.com/articles?page[number]=1&page[size]=1",
+        "last" => "http://example.com/articles?page[number]=13&page[size]=1",
+        "next" => "http://example.com/articles?page[number]=4&page[size]=1",
+        "prev" => "http://example.com/articles?page[number]=2&page[size]=1",
+        "self" => "http://example.com/articles?page[number]=3&page[size]=1"
+      },
+      meta: %{
+        "total-pages" => 13
+      }
+    }
+    assert_idempotent document, error_template
+  end
+
+  ## See http://jsonapi.org/examples/#error-objects
+
+  test "basic error object" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "errors": [
+        {
+          "status": "422",
+          "source": {"pointer": "/data/attributes/first-name"},
+          "title":  "Invalid Attribute",
+          "detail": "First name must contain at least three characters."
+        }
+      ]
+    }
+    """
+    error_template = %Error{@error_template | meta: %{"action" => :create, "sender" => :server}}
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      errors: [
+        %Error{
+          detail: "First name must contain at least three characters.",
+          source: %Source{
+            pointer: "/data/attributes/first-name"
+          },
+          status: "422",
+          title: "Invalid Attribute"
+        }
+      ]
+    }
+    assert_idempotent document, error_template
+  end
+
+  ## See http://jsonapi.org/examples/#error-objects-multiple-errors
+
+  test "multiple errors on different attributes" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "errors": [
+        {
+          "status": "403",
+          "source": {"pointer": "/data/attributes/secret-powers"},
+          "detail": "Editing secret powers is not authorized on Sundays."
+        },
+        {
+          "status": "422",
+          "source": {"pointer": "/data/attributes/volume"},
+          "detail": "Volume does not, in fact, go to 11."
+        },
+        {
+          "status": "500",
+          "source": {"pointer": "/data/attributes/reputation"},
+          "title": "The backend responded with an error",
+          "detail": "Reputation service not responding after three requests."
+        }
+      ]
+    }
+    """
+    error_template = %Error{@error_template | meta: %{"action" => :update, "sender" => :server}}
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      errors: [
+        %Error{
+          detail: "Editing secret powers is not authorized on Sundays.",
+          source: %Source{
+            pointer: "/data/attributes/secret-powers"
+          },
+          status: "403"
+        },
+        %Error{
+          detail: "Volume does not, in fact, go to 11.",
+          source: %Source{
+            pointer: "/data/attributes/volume"
+          },
+          status: "422"
+        },
+        %Error{
+          detail: "Reputation service not responding after three requests.",
+          source: %Source{
+            pointer: "/data/attributes/reputation"
+          },
+          status: "500",
+          title: "The backend responded with an error"
+        }
+      ]
+    }
+    assert_idempotent document, error_template
+  end
+
+  test "multiple errors on same attribute" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "errors": [
+        {
+          "source": {"pointer": "/data/attributes/first-name"},
+          "title": "Invalid Attribute",
+          "detail": "First name must contain at least three characters."
+        },
+        {
+          "source": {"pointer": "/data/attributes/first-name"},
+          "title": "Invalid Attribute",
+          "detail": "First name must contain an emoji."
+        }
+      ]
+    }
+    """
+    error_template = %Error{@error_template | meta: %{"action" => :create, "sender" => :server}}
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      errors: [
+        %Error{
+          detail: "First name must contain at least three characters.",
+          source: %Source{
+            pointer: "/data/attributes/first-name"
+          },
+          title: "Invalid Attribute"
+        },
+        %Error{
+          detail: "First name must contain an emoji.",
+          source: %Source{
+            pointer: "/data/attributes/first-name"
+          },
+          title: "Invalid Attribute"
+        }
+      ]
+    }
+    assert_idempotent document, error_template
+  end
+
+  ## See http://jsonapi.org/examples/#error-objects-error-codes
+
+  test "error codes" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "jsonapi": {"version": "1.0"},
+      "errors": [
+        {
+          "code":   "123",
+          "source": {"pointer": "/data/attributes/first-name"},
+          "title":  "Value is too short",
+          "detail": "First name must contain at least three characters."
+        },
+        {
+          "code":   "225",
+          "source": {"pointer": "/data/attributes/password"},
+          "title": "Passwords must contain a letter, number, and punctuation character.",
+          "detail": "The password provided is missing a punctuation character."
+        },
+        {
+          "code":   "226",
+          "source": {"pointer": "/data/attributes/password"},
+          "title": "Password and password confirmation do not match."
+        }
+      ]
+    }
+    """
+    error_template = %Error{@error_template | meta: %{"action" => :create, "sender" => :server}}
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      errors: [
+        %Error{
+          code: "123",
+          detail: "First name must contain at least three characters.",
+          source: %Source{
+            pointer: "/data/attributes/first-name"
+          },
+          title: "Value is too short"
+        },
+        %Error{
+          code: "225",
+          detail: "The password provided is missing a punctuation character.",
+          source: %Source{
+            pointer: "/data/attributes/password"
+          },
+          title: "Passwords must contain a letter, number, and punctuation character."
+        },
+        %Error{
+          code: "226",
+          source: %Source{
+            pointer: "/data/attributes/password"
+          },
+          title: "Password and password confirmation do not match."
+        }
+      ]
+    }
+    assert_idempotent document, error_template
+  end
+
+  ## See http://jsonapi.org/examples/#error-objects-source-usage
+
+  test "advanced source usage" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "errors": [
+        {
+          "source": {"pointer": ""},
+          "detail":  "Missing `data` Member at document's top level."
+        }
+      ]
+    }
+    """
+    error_template = %Error{@error_template | meta: %{"action" => :create, "sender" => :server}}
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      errors: [
+        %Error{
+          detail: "Missing `data` Member at document's top level.",
+          source: %Source{
+            pointer: ""
+          }
+        }
+      ]
+    }
+    assert_idempotent document, error_template
+  end
+
+  test "invalid JSON" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "errors": [{
+        "status": "400",
+        "detail": "JSON parse error - Expecting property name at line 1 column 2 (char 1)."
+      }]
+    }
+    """
+    error_template = %Error{@error_template | meta: %{"action" => :create, "sender" => :server}}
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      errors: [
+        %Error{
+          detail: "JSON parse error - Expecting property name at line 1 column 2 (char 1).",
+          status: "400"
+        }
+      ]
+    }
+    assert_idempotent document, error_template
+  end
+
+  ## See http://jsonapi.org/examples/#error-objects-invalid-query-parameters
+
+  test "invalid query parameters" do
+    {:ok, decoded} = Poison.decode """
+    {
+      "errors": [
+        {
+          "source": {"parameter": "include"},
+          "title":  "Invalid Query Parameter",
+          "detail": "The resource does not have an `auther` relationship path."
+        }
+      ]
+    }
+    """
+    error_template = %Error{@error_template | meta: %{"action" => :create, "sender" => :server}}
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert document == %Document{
+      errors: [
+        %Error{
+          detail: "The resource does not have an `auther` relationship path.",
+          source: %Source{
+            parameter: "include"
+          },
+          title: "Invalid Query Parameter"
+        }
+      ]
+    }
+    assert_idempotent document, error_template
+  end
+
+  # Private Functions
+
+  defp assert_idempotent(start, error_template \\ @error_template)
+
+  defp assert_idempotent(original = %Document{}, error_template) do
     FromJsonCase.assert_idempotent error_template: error_template,
                                    module: Document,
-                                   original: response
+                                   original: original
+  end
+
+  defp assert_idempotent(encoded_json, error_template) do
+    {:ok, decoded} = Poison.decode(encoded_json)
+    {:ok, document} = Document.from_json(decoded, error_template)
+
+    assert_idempotent(document)
   end
 end

--- a/test/alembic/document_test.exs
+++ b/test/alembic/document_test.exs
@@ -7,7 +7,7 @@ defmodule Alembic.DocumentTest do
 
   alias Alembic.Document
   alias Alembic.Error
-  alias Alembic.FromJsonTest
+  alias Alembic.FromJsonCase
   alias Alembic.Source
 
   doctest Document
@@ -21,7 +21,7 @@ defmodule Alembic.DocumentTest do
 
     {:error, response} = Document.from_json(%{}, error_template)
 
-    FromJsonTest.assert_idempotent error_template: error_template,
+    FromJsonCase.assert_idempotent error_template: error_template,
                                    module: Document,
                                    original: response
   end

--- a/test/alembic/error_test.exs
+++ b/test/alembic/error_test.exs
@@ -6,7 +6,7 @@ defmodule Alembic.ErrorTest do
   use ExUnit.Case, async: true
 
   alias Alembic.Error
-  alias Alembic.FromJsonTest
+  alias Alembic.FromJsonCase
   alias Alembic.Source
 
   # Constants
@@ -48,7 +48,7 @@ defmodule Alembic.ErrorTest do
   # Private Functions
 
   defp assert_idempotent(original) do
-    FromJsonTest.assert_idempotent error_template: %Error{
+    FromJsonCase.assert_idempotent error_template: %Error{
                                                      source: %Source{
                                                        pointer: "/errors/0"
                                                      }

--- a/test/alembic/from_json_test.exs
+++ b/test/alembic/from_json_test.exs
@@ -5,20 +5,6 @@ defmodule Alembic.FromJsonTest do
 
   use ExUnit.Case, async: true
 
-  # Functions
-
-  def assert_idempotent(options) do
-    error_template = Keyword.get options, :error_template
-    module = Keyword.get options, :module
-    original = Keyword.get options, :original
-
-    {:ok, encoded} = Poison.encode(original)
-    {:ok, decoded} = Poison.decode(encoded)
-    {:ok, from_decoded} = module.from_json(decoded, error_template)
-
-    assert from_decoded == original
-  end
-
   # Tests
 
   doctest Alembic.FromJson

--- a/test/alembic/relationship_test.exs
+++ b/test/alembic/relationship_test.exs
@@ -1,0 +1,9 @@
+defmodule Alembic.RelationshipTest do
+  @moduledoc """
+  Runs doctests for `Alembic.Relationship`
+  """
+
+  use ExUnit.Case, async: true
+
+  doctest Alembic.Relationship
+end

--- a/test/alembic/relationships_test.exs
+++ b/test/alembic/relationships_test.exs
@@ -1,0 +1,9 @@
+defmodule Alembic.RelationshipsTest do
+  @moduledoc """
+  Runs doctests for `Alembic.Relationships`
+  """
+
+  use ExUnit.Case, async: true
+
+  doctest Alembic.Relationships
+end

--- a/test/alembic/resource_identifier_test.exs
+++ b/test/alembic/resource_identifier_test.exs
@@ -1,0 +1,9 @@
+defmodule InterpreterServer.Rpc.ResourceIdentifierTest do
+  @moduledoc """
+  Runs doctests for `Alembic.ResourceIdentifier`
+  """
+
+  use ExUnit.Case, async: true
+
+  doctest Alembic.ResourceIdentifier
+end

--- a/test/alembic/resource_linkage_test.exs
+++ b/test/alembic/resource_linkage_test.exs
@@ -1,0 +1,9 @@
+defmodule Alembic.ResourceLinkageTest do
+  @moduledoc """
+  Runs doctests for `Alembic.ResourceLinkage`
+  """
+
+  use ExUnit.Case, async: true
+
+  doctest Alembic.ResourceLinkage
+end

--- a/test/alembic/resource_test.exs
+++ b/test/alembic/resource_test.exs
@@ -1,0 +1,9 @@
+defmodule Alembic.ResourceTest do
+  @moduledoc """
+  Runs doctests for `Alembic.Resource`
+  """
+
+  use ExUnit.Case, async: true
+
+  doctest Alembic.Resource
+end

--- a/test/alembic/source_test.exs
+++ b/test/alembic/source_test.exs
@@ -5,8 +5,8 @@ defmodule Alembic.SourceTest do
 
   use ExUnit.Case, async: true
 
-  alias Alembic.FromJsonTest
   alias Alembic.Error
+  alias Alembic.FromJsonCase
   alias Alembic.Source
 
   # Tests
@@ -24,7 +24,7 @@ defmodule Alembic.SourceTest do
   # Private Functions
 
   defp assert_idempotent(original) do
-    FromJsonTest.assert_idempotent error_template: %Error{
+    FromJsonCase.assert_idempotent error_template: %Error{
                                                      source: %Source{
                                                        pointer: "/errors/0/source"
                                                      }

--- a/test/poison/encoder/alembic/document_test.exs
+++ b/test/poison/encoder/alembic/document_test.exs
@@ -1,0 +1,9 @@
+defmodule Poison.Encoder.Alembic.DocumentTest do
+  @moduledoc """
+  Runs doctess for `Poison.Encoder` implementation for `Alembic.Document`
+  """
+
+  use ExUnit.Case, async: true
+
+  doctest Poison.Encoder.Alembic.Document
+end

--- a/test/poison/encoder/alembic/resource_test.exs
+++ b/test/poison/encoder/alembic/resource_test.exs
@@ -1,0 +1,9 @@
+defmodule Poison.Encoder.Alembic.ResourceTest do
+  @moduledoc """
+  Runs doctess for `Poison.Encoder` implementation for `Alembic.Resource`
+  """
+
+  use ExUnit.Case, async: true
+
+  doctest Poison.Encoder.Alembic.Resource
+end

--- a/test/support/from_json_case.ex
+++ b/test/support/from_json_case.ex
@@ -1,0 +1,33 @@
+defmodule Alembic.FromJsonCase do
+  @moduledoc """
+  Helpers for testing `from_json/2` implementations
+  """
+
+  import ExUnit.Assertions
+
+  @doc """
+  Asserts that the `:original` can be encoded, decode, and parsed from json and get back the `:original`, which proves
+  idempotence of the `Poison.Encoder` implementation plus `Alembic.FromJson.from_json/2` callback cycle.
+
+  ## Options
+
+  All options are required.  They are just in a Keyword to make it clearer the meaning of each option
+
+  * `:error_template` - `Alembic.Error.t` passed to `:module`'s `from_json/2`.
+  * `:module` - Module with `@behaviour Alembic.FromJson`, so that it implements
+    `Alembic.FromJson.from_json/2` callback.
+  * `:original` - The original `Alembic` namespace struct that should be tested for encoding and parsing
+    idempotence.
+  """
+  def assert_idempotent(options) do
+    error_template = Keyword.get options, :error_template
+    module = Keyword.get options, :module
+    original = Keyword.get options, :original
+
+    {:ok, encoded} = Poison.encode(original)
+    {:ok, decoded} = Poison.decode(encoded)
+    {:ok, from_decoded} = module.from_json(decoded, error_template)
+
+    assert from_decoded == original
+  end
+end


### PR DESCRIPTION
# Changelog
* Enhancements
  * `Alembic.ResourceIdentifier`
  * `Alembic.ResourceLinkage`
  * `Alembic.Relationship`
  * `Alembic.Relationships`
  * `Alembic.Resource`
  * `Alembic.Document` can parse `from_json`, represent, and encode with `Poison.encode` all document format, including `data` and `meta`, in addition to the prior support for `errors`
  * `assert_idempotent` is defined in a module, `Alembic.FromJsonCase` under `test/support`, so it's no longer necessary to run `mix test <file> test/interpreter_server/api/from_json_test.exs` to get access to `assert_idempotent` in `<file>`.
* Incompatible Changes
  * `Alembic.FromJsonTest.assert_idempotent` has moved to `Alembic.FromJsonCase`.

# Upgrading
Instead of using `Alembic.FromJsonTest.assert_idempotent` use `Alembic.FromJsonCase.assert_idempotent` instead.  `Alembic.FromJsonCase` is defined in `test/support/from_json_case.ex`, so there is no need to explicitly include it when running a single file with `mix test <file>`.
