### PR TITLE
1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+## v1.0.0
+ 
+### Enhancements
+* [#1](https://github.com/C-S-D/alembic/pull/1) - [KronicDeth](https://github.com/KronicDeth)
+  * CircleCI build setup
+  * JUnit formatter for CircleCI's test output parsing
+* [#2](https://github.com/C-S-D/alembic/pull/2) - [KronicDeth](https://github.com/KronicDeth)
+  * `mix test --cover` with CoverEx
+  * Archive coverage reports on CircleCI
+* [#3](https://github.com/C-S-D/alembic/pull/3) - [KronicDeth](https://github.com/KronicDeth)
+  * Use `ex_doc` and `earmark` to generate documentation with `mix docs`
+  * Use `mix inch (--pedantic)` to see coverage for documentation
+* [#4](https://github.com/C-S-D/alembic/pull/4) - [KronicDeth](https://github.com/KronicDeth)
+  * Add repository to [hexfaktor](http://hexfaktor.org/), so that outdated hex dependencies are automatically notified through CI.
+  * Add [hexfaktor](http://hexfaktor.org/) badge to [README.md](README.md)
+* [#5](https://github.com/C-S-D/alembic/pull/5) - [KronicDeth](https://github.com/KronicDeth)
+  * Configure `mix credo` to run against `lib` and `test` to maintain consistency with Ruby projects that use `rubocop` on `lib` and `spec`.
+  * Run `mix credo --strict` on CircleCI to check style and consistency in CI
+* [#6](https://github.com/C-S-D/alembic/pull/6) - [KronicDeth](https://github.com/KronicDeth)
+  * Use [`dialyze`](https://github.com/fishcakez/dialyze) for dialyzer access with `mix dialyze`
+* [#7](https://github.com/C-S-D/alembic/pull/7) - Validation and conversion of JSON API errors Documents - [KronicDeth](https://github.com/KronicDeth)
+  * JSON API errors documents can be validated and converted to `%Alembic.Document{}` using `Alembic.Document.from_json/2`.  Invalid documents return `{:error, %Alembic.Document{}}`.  The `%Alembic.Document{}` can be sent back to the sender, which can be validated on the other end using `from_json/2`.  Valid documents return `{:ok, %Alembic.Document{}}`.
+* [#8](https://github.com/C-S-D/alembic/pull/8) - JSON API (non-errors) Documents - [KronicDeth](https://github.com/KronicDeth)
+  * `Alembic.ResourceIdentifier`
+  * `Alembic.ResourceLinkage`
+  * `Alembic.Relationship`
+  * `Alembic.Relationships`
+  * `Alembic.Resource`
+  * `Alembic.Document` can parse `from_json`, represent, and encode with `Poison.encode` all document format, including `data` and `meta`, in addition to the prior support for `errors`
+  * `assert_idempotent` is defined in a module, `Alembic.FromJsonCase` under `test/support`, so it's no longer necessary to run `mix test <file> test/interpreter_server/api/from_json_test.exs` to get access to `assert_idempotent` in `<file>`.  
+
+### Bug Fixes
+
+### Incompatible Changes
+* [#8](https://github.com/C-S-D/alembic/pull/8) - JSON API (non-errors) Documents - [KronicDeth](https://github.com/KronicDeth)
+  * `Alembic.FromJsonTest.assert_idempotent` has moved to `Alembic.FromJsonCase`.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Changelog](#changelog)
+  - [v1.0.0](#v100)
+    - [Enhancements](#enhancements)
+    - [Bug Fixes](#bug-fixes)
+    - [Incompatible Changes](#incompatible-changes)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Changelog
 
 ## v1.0.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+## Forking
+
+[Fork this repository](https://github.com/C-S-D/alembic/fork)
+
+## Development
+
+1. Create your feature branch (`git checkout -b my-new-feature`)
+2. Commit your changes (`git commit -am 'Add some feature'`)
+3. Push to the branch (`git push origin my-new-feature`)
+
+## Testing
+
+1. Ensure all unit and doctests pass: `mix test`
+2. Ensure all style and consistency checks pass: `mix credo --strict`
+3. Ensure no dialyzer warnings: `mix dialyze`
+
+## Pull Request
+
+[Create a Pull Request](https://github.com/C-S-D/alembic/compare/)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,194 @@
+Apache License
+==============
+
+_Version 2.0, January 2004_  
+_&lt;<http://www.apache.org/licenses/>&gt;_
+
+### Terms and Conditions for use, reproduction, and distribution
+
+#### 1. Definitions
+
+“License” shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+“Licensor” shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+“Legal Entity” shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, “control” means **(i)** the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or **(ii)** ownership of fifty percent (50%) or more of the
+outstanding shares, or **(iii)** beneficial ownership of such entity.
+
+“You” (or “Your”) shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+“Source” form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+“Object” form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+“Work” shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+“Derivative Works” shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+“Contribution” shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+“submitted” means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as “Not a Contribution.”
+
+“Contributor” shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+#### 2. Grant of Copyright License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+#### 3. Grant of Patent License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+#### 4. Redistribution
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+* **(a)** You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+* **(b)** You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+* **(c)** You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+* **(d)** If the Work includes a “NOTICE” text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+#### 5. Submission of Contributions
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+#### 6. Trademarks
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+#### 7. Disclaimer of Warranty
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an “AS IS” BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+#### 8. Limitation of Liability
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+#### 9. Accepting Warranty or Additional Liability
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+_END OF TERMS AND CONDITIONS_
+
+### APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets `[]` replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same “printed page” as the copyright notice for easier identification within
+third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+      http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Deps Status](https://beta.hexfaktor.org/badge/all/github/C-S-D/alembic.svg)](https://beta.hexfaktor.org/github/C-S-D/alembic)
 [![Inline docs](http://inch-ci.org/github/C-S-D/alembic.svg)](http://inch-ci.org/github/C-S-D/alembic)
 
-**TODO: Add description**
+A JSONAPI 1.0 library fully-tested against all jsonapi.org examples.  The library generates JSONAPI errors documents whenever it encounters a malformed JSONAPI document, so that servers don't need to worry about JSONAPI format errors.  Poison.Encoder implementations ensure the structs can be turned back into JSON strings: struct->encoding->decoding->conversion to struct is tested to ensure idempotency and that the library can parse its own JSONAPI errors documents.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
   1. Add alembic to your list of dependencies in `mix.exs`:
 
         def deps do
-          [{:alembic, "~> 0.0.1"}]
+          [{:alembic, "~> 1.0.0"}]
         end
 
   2. Ensure alembic is started before your application:

--- a/README.md
+++ b/README.md
@@ -22,3 +22,6 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
           [applications: [:alembic]]
         end
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Alembic](#alembic)
+  - [Installation](#installation)
+  - [Contributing](#contributing)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Alembic
 
 [![CircleCI](https://circleci.com/gh/C-S-D/alembic.svg?style=svg)](https://circleci.com/gh/C-S-D/alembic)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,12 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Upgrading](#upgrading)
+  - [v1.0.0](#v100)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Upgrading
 
 ## v1.0.0

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,5 @@
+# Upgrading
+
+## v1.0.0
+
+Instead of using `Alembic.FromJsonTest.assert_idempotent` use `Alembic.FromJsonCase.assert_idempotent`.  `Alembic.FromJsonCase` is defined in `test/support/from_json_case.ex`, so there is no need to explicitly include it when running a single file with `mix test <file>`.

--- a/circle.yml
+++ b/circle.yml
@@ -14,12 +14,13 @@ dependencies:
     - ln -s /home/ubuntu/elixir/bin/* /home/ubuntu/bin
     - mix local.hex --force && mix local.rebar --force
   post:
-    - mix deps.get
+    - mix deps.get --only test
 test:
   override:
     - mix test --cover
   post:
     - mix credo --strict
+    - mix dialyze
     - mix inch.report
     - cp -a cover ${CIRCLE_ARTIFACTS}/
     - mkdir -p ${CIRCLE_TEST_REPORTS}/Elixir

--- a/circle.yml
+++ b/circle.yml
@@ -3,8 +3,11 @@ machine:
     MIX_ENV: test
 dependencies:
   cache_directories:
-    - ../erlang-solutions
     - ../elixir
+    - ../erlang-solutions
+    - /home/ubuntu/.mix
+    - _build
+    - deps
   pre:
     - if [[ ! -e ../erlang-solutions ]]; then cd .. && wget http://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && mkdir erlang-solutions && mv erlang-solutions_1.0_all.deb erlang-solutions && cd -; fi
     - sudo dpkg -i /home/ubuntu/erlang-solutions/erlang-solutions_1.0_all.deb
@@ -15,6 +18,9 @@ dependencies:
     - mix local.hex --force && mix local.rebar --force
   post:
     - mix deps.get --only test
+    - mix compile
+    # generate plts so they are stored in cache of /home/ubuntu/.mix and _build
+    - mix dialyze --no-analyse
 test:
   override:
     - mix test --cover

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule Alembic.Mixfile do
       # test coverge tool.  Allow `--cover` option for `mix test`
       {:coverex, "~> 1.4", only: :test},
       # success type checker: ensures @type and @spec are valid
-      {:dialyze, "~> 0.2.1", only: :dev},
+      {:dialyze, "~> 0.2.1", only: [:dev, :test]},
       # markdown to HTML converter for ex_doc
       {:earmark, "~> 0.2.1", only: :dev},
       # documentation generation

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Alembic.Mixfile do
       source_url: "https://github.com/C-S-D/alembic",
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: Coverex.Task],
-      version: "0.0.1"
+      version: "1.0.0"
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -14,10 +14,12 @@ defmodule Alembic.Mixfile do
     [
       app: :alembic,
       build_embedded: Mix.env == :prod,
+      description: description,
       deps: deps,
       elixir: "~> 1.2",
       elixirc_paths: elixirc_paths(Mix.env),
       name: "Alembic",
+      package: package,
       source_url: "https://github.com/C-S-D/alembic",
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: Coverex.Task],
@@ -57,6 +59,27 @@ defmodule Alembic.Mixfile do
     ]
   end
 
+  defp description do
+    """
+    A JSONAPI 1.0 library fully-tested against all jsonapi.org examples.  The library generates JSONAPI errors documents
+    whenever it encounters a malformed JSONAPI document, so that servers don't need to worry about JSONAPI format
+    errors.  Poison.Encoder implementations ensure the structs can be turned back into JSON strings:
+    struct->encoding->decoding->conversion to struct is tested to ensure idempotency and that the library
+    can parse its own JSONAPI errors documents.
+    """
+  end
+
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_),     do: ["lib"]
+
+  defp package do
+    [
+      licenses: ["Apache 2.0"],
+      links: %{
+        "Docs" => "https://hexdocs.pm/alembic",
+        "Github" => "https://github.com/C-S-D/alembic",
+      },
+      maintainers: ["Luke Imhoff"]
+    ]
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -16,6 +16,7 @@ defmodule Alembic.Mixfile do
       build_embedded: Mix.env == :prod,
       description: description,
       deps: deps,
+      docs: docs,
       elixir: "~> 1.2",
       elixirc_paths: elixirc_paths(Mix.env),
       name: "Alembic",
@@ -69,11 +70,29 @@ defmodule Alembic.Mixfile do
     """
   end
 
+  defp docs do
+    [
+      extras: extras
+    ]
+  end
+
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_),     do: ["lib"]
 
+  defp extras do
+    [
+      "CHANGELOG.md",
+      "CODE_OF_CONDUCT.md",
+      "CONTRIBUTING.md",
+      "LICENSE.md",
+      "README.md",
+      "UPGRADING.md"
+    ]
+  end
+
   defp package do
     [
+      files: ["lib", "mix.exs" | extras],
       licenses: ["Apache 2.0"],
       links: %{
         "Docs" => "https://hexdocs.pm/alembic",


### PR DESCRIPTION
# Changelog
## Enhancements
* Update version to `1.0.0`
* Fill in `description` and `package` for hex
* Add `CODE_OF_CONDUCT.md`
* Add `CONTRIBUTING.md`
* Add `CHANGLOG.md` and `UPDATING.md` that cover all previous PRs for `1.0.0` release
* Use `doctoc` to generate table of contents in `CHANGELOG.md`, `README.md`, and `UPGRADING.md`
* Add `LICENSE.md` for "Apache 2.0" license configured in `package` for hex
* Include `CHANGELOG.md`, `CODE_OF_CONDUCT.md`, CONTRIBUTING.md`, `LICENSE.md`, `README.md`, and `UPGRADING.md` in docs and package.
* Run `mix dialyze` on CircleCI since it currently has no warnings
* Cache build output on CircleCI by running `mix compile` and `mix dialyze --no-analyse` as part of the `dependencies` `post` and including more directories in `cache_directories`:
  * Cache /home/ubuntu/.mix as it contains plt for `mix dialyze` that take ~6 minutes to compute
  * Cache _build because it contains separate, per environment plt for `mix dialyze that is part of the ~6 minutes and all the compiled deps
  * Cache deps so `mix deps.get` is faster.