### PR TITLE
ToEctoSchema and ToParams

### DIFF
--- a/lib/alembic/document.ex
+++ b/lib/alembic/document.ex
@@ -3,16 +3,19 @@ defmodule Alembic.Document do
   JSON API refers to the top-level JSON structure as a [document](http://jsonapi.org/format/#document-structure).
   """
 
+  alias Alembic
   alias Alembic.Error
   alias Alembic.FromJson
   alias Alembic.Links
   alias Alembic.Meta
   alias Alembic.Resource
   alias Alembic.ResourceLinkage
+  alias Alembic.ToParams
 
   # Behaviours
 
   @behaviour FromJson
+  @behaviour ToParams
 
   # Constants
 
@@ -620,6 +623,184 @@ defmodule Alembic.Document do
   end
 
   @doc """
+  Lookup table of `included` resources, so that `Alembic.ResourceIdentifier.t` can be
+  converted to full `Alembic.Resource.t`.
+
+  ## No included resources
+
+  With no included resources, an empty map is returned
+
+      iex> {:ok, document} = Alembic.Document.from_json(
+      ...>   %{
+      ...>     "data" => %{
+      ...>       "type" => "post",
+      ...>       "id" => "1"
+      ...>     }
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :fetch,
+      ...>       "sender" => :server
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: ""
+      ...>     }
+      ...>   }
+      ...> )
+      ...> Alembic.Document.included_resource_by_id_by_type(document)
+      %{}
+
+  ## Included resources
+
+  With included resources, a nest map is built with the outer layer keyed by the `Alembic.Resource.type`,
+  then the next layer keyed by the `Alembic.Resource.id` with the values being the full
+  `Alembic.Resource.t`
+
+      iex> {:ok, document} = Alembic.Document.from_json(
+      ...>   %{
+      ...>     "data" => [
+      ...>       %{
+      ...>         "type" => "articles",
+      ...>         "id" => "1",
+      ...>         "relationships" => %{
+      ...>           "author" => %{
+      ...>             "data" => %{
+      ...>               "type" => "people",
+      ...>               "id" => "9"
+      ...>             }
+      ...>           },
+      ...>           "comments" => %{
+      ...>             "data" => [
+      ...>               %{
+      ...>                 "type" => "comments",
+      ...>                 "id" => "5"
+      ...>               },
+      ...>               %{
+      ...>                 "type" => "comments",
+      ...>                 "id" => "12"
+      ...>               }
+      ...>             ]
+      ...>           }
+      ...>         }
+      ...>       }
+      ...>     ],
+      ...>     "included" => [
+      ...>       %{
+      ...>         "type" => "people",
+      ...>         "id" => "9",
+      ...>         "attributes" => %{
+      ...>           "first-name" => "Dan",
+      ...>           "last-name" => "Gebhardt",
+      ...>           "twitter" => "dgeb"
+      ...>         }
+      ...>       },
+      ...>       %{
+      ...>         "type" => "comments",
+      ...>         "id" => "5",
+      ...>         "attributes" => %{
+      ...>           "body" => "First!"
+      ...>         },
+      ...>         "relationships" => %{
+      ...>           "author" => %{
+      ...>             "data" => %{
+      ...>               "type" => "people",
+      ...>               "id" => "2"
+      ...>             }
+      ...>           }
+      ...>         }
+      ...>       },
+      ...>       %{
+      ...>         "type" => "comments",
+      ...>         "id" => "12",
+      ...>         "attributes" => %{
+      ...>           "body" => "I like XML better"
+      ...>         },
+      ...>         "relationships" => %{
+      ...>           "author" => %{
+      ...>             "data" => %{
+      ...>               "type" => "people",
+      ...>               "id" => "9"
+      ...>             }
+      ...>           }
+      ...>         }
+      ...>       }
+      ...>     ]
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :fetch,
+      ...>       "sender" => :server
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: ""
+      ...>     }
+      ...>   }
+      ...> )
+      ...> Alembic.Document.included_resource_by_id_by_type(document)
+      %{
+        "comments" => %{
+          "12" => %Alembic.Resource{
+            attributes: %{
+              "body" => "I like XML better"
+            },
+            id: "12",
+            relationships: %{
+              "author" => %Alembic.Relationship{
+                data: %Alembic.ResourceIdentifier{
+                  id: "9",
+                  type: "people"
+                }
+              }
+            },
+            type: "comments"
+          },
+          "5" => %Alembic.Resource{
+            attributes: %{
+              "body" => "First!"
+            },
+            id: "5",
+            relationships: %{
+              "author" => %Alembic.Relationship{
+                data: %Alembic.ResourceIdentifier{
+                  id: "2",
+                  type: "people"
+                }
+              }
+            },
+            type: "comments"
+          }
+        },
+        "people" => %{
+          "9" => %Alembic.Resource{
+            attributes: %{
+              "first-name" => "Dan",
+              "last-name" => "Gebhardt",
+              "twitter" => "dgeb"
+            },
+            id: "9",
+            type: "people"
+          }
+        }
+      }
+
+  """
+  @spec included_resource_by_id_by_type(t) :: ToParams.resource_by_id_by_type
+
+  def included_resource_by_id_by_type(%__MODULE__{included: nil}), do: %{}
+
+  def included_resource_by_id_by_type(%__MODULE__{included: included}) do
+    Enum.reduce(
+      included,
+      %{},
+      fn (resource = %Resource{id: id, type: type}, resource_by_id_by_type) ->
+        resource_by_id_by_type
+        |> Map.put_new(type, %{})
+        |> put_in([type, id], resource)
+      end
+    )
+  end
+
+  @doc """
   Merges the errors from two documents together.
 
   The errors from the second document are prepended to the errors of the first document so that the errors as a whole
@@ -685,6 +866,252 @@ defmodule Alembic.Document do
   def reverse(document = %__MODULE__{errors: errors}) when is_list(errors) do
     %__MODULE__{document | errors: Enum.reverse(errors)}
   end
+
+  @doc """
+  Transforms a `t` into the nested params format used by
+  [`Ecto.Changeset.cast/4`](http://hexdocs.pm/ecto/Ecto.Changeset.html#cast/4).
+
+  ## No resource
+
+  No resource is transformed to an empty map
+
+      iex> {:ok, document} = Alembic.Document.from_json(
+      ...>   %{
+      ...>     "data" => nil
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :fetch,
+      ...>       "sender" => :server
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: ""
+      ...>     }
+      ...>   }
+      ...> )
+      iex> Alembic.Document.to_params(document)
+      %{}
+
+  ## Single resource
+
+  A single resource is converted to a params map that combines the id and attributes.
+
+      iex> {:ok, document} = Alembic.Document.from_json(
+      ...>   %{
+      ...>     "data" => %{
+      ...>       "attributes" => %{
+      ...>         "name" => "Thing 1"
+      ...>       },
+      ...>       "id" => "1",
+      ...>       "type" => "thing"
+      ...>     }
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :fetch,
+      ...>       "sender" => :server
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: ""
+      ...>     }
+      ...>   }
+      ...> )
+      iex> Alembic.Document.to_params(document)
+      %{
+        "id" => "1",
+        "name" => "Thing 1"
+      }
+
+  ### Relationships
+
+  Relationships are merged into the params for the resource
+
+      iex> {:ok, document} = Alembic.Document.from_json(
+      ...>   %{
+      ...>     "data" => %{
+      ...>       "attributes" => %{
+      ...>         "name" => "Thing 1"
+      ...>       },
+      ...>       "id" => "1",
+      ...>       "relationships" => %{
+      ...>         "shirt" => %{
+      ...>           "data" => %{
+      ...>             "attributes" => %{
+      ...>               "size" => "L"
+      ...>             },
+      ...>             "type" => "shirt"
+      ...>           }
+      ...>         }
+      ...>       },
+      ...>       "type" => "thing"
+      ...>     }
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: ""
+      ...>     }
+      ...>   }
+      ...> )
+      iex> Alembic.Document.to_params(document)
+      %{
+        "id" => "1",
+        "name" => "Thing 1",
+        "shirt" => %{
+          "size" => "L"
+        }
+      }
+
+  ## Multiple resources
+
+  Multiple resources are converted to a params list where each element is a map that combines the id and attributes
+
+      iex> {:ok, document} = Alembic.Document.from_json(
+      ...>   %{
+      ...>     "data" => [
+      ...>       %{
+      ...>         "type" => "post",
+      ...>         "id" => "1",
+      ...>         "attributes" => %{
+      ...>           "text" => "Welcome"
+      ...>         }
+      ...>       },
+      ...>       %{
+      ...>         "type" => "post",
+      ...>         "id" => "2",
+      ...>         "attributes" => %{
+      ...>           "text" => "It's been awhile"
+      ...>         }
+      ...>       }
+      ...>     ]
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :fetch,
+      ...>       "sender" => :server
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: ""
+      ...>     }
+      ...>   }
+      ...> )
+      iex> Alembic.Document.to_params(document)
+      [
+        %{
+          "id" => "1",
+          "text" => "Welcome"
+        },
+        %{
+          "id" => "2",
+          "text" => "It's been awhile"
+        }
+      ]
+
+  ### Relationships
+
+  Relationships are merged into the params for the corresponding resource
+
+      iex> {:ok, document} = Alembic.Document.from_json(
+      ...>   %{
+      ...>     "data" => [
+      ...>       %{
+      ...>         "type" => "post",
+      ...>         "id" => "1",
+      ...>         "attributes" => %{
+      ...>           "text" => "Welcome"
+      ...>         },
+      ...>         "relationships" => %{
+      ...>           "comments" => %{
+      ...>             "data" => [
+      ...>               %{
+      ...>                 "type" => "comment",
+      ...>                 "id" => "1"
+      ...>               }
+      ...>             ]
+      ...>           }
+      ...>         }
+      ...>       },
+      ...>       %{
+      ...>         "type" => "post",
+      ...>         "id" => "2",
+      ...>         "attributes" => %{
+      ...>           "text" => "It's been awhile"
+      ...>         },
+      ...>         "relationships" => %{
+      ...>           "comments" => %{
+      ...>             "data" => []
+      ...>           }
+      ...>         }
+      ...>       }
+      ...>     ],
+      ...>     "included" => [
+      ...>       %{
+      ...>         "type" => "comment",
+      ...>         "id" => "1",
+      ...>         "attributes" => %{
+      ...>           "text" => "First!"
+      ...>         }
+      ...>       }
+      ...>     ]
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :fetch,
+      ...>       "sender" => :server
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: ""
+      ...>     }
+      ...>   }
+      ...> )
+      iex> Alembic.Document.to_params(document)
+      [
+        %{
+          "id" => "1",
+          "text" => "Welcome",
+          "comments" => [
+            %{
+              "id" => "1",
+              "text" => "First!"
+            }
+          ]
+        },
+        %{
+          "id" => "2",
+          "text" => "It's been awhile",
+          "comments" => []
+        }
+      ]
+
+  """
+  @spec to_params(t) :: [map] | map
+  def to_params(document = %__MODULE__{}) do
+    resource_by_id_by_type = included_resource_by_id_by_type(document)
+    to_params(document, resource_by_id_by_type)
+  end
+
+  @doc """
+  Transforms a `t` into the nested params format used by
+  [`Ecto.Changeset.cast/4`](http://hexdocs.pm/ecto/Ecto.Changeset.html#cast/4) using the given
+  `resources_by_id_by_type`.
+
+  See `Alembic.Document.to_params/1`
+  """
+  @spec to_params(%__MODULE__{data: [Resource.t] | Resource.t | nil},
+                  ToParams.resource_by_id_by_type) :: ToParams.params
+
+  def to_params(%__MODULE__{data: data}, resource_by_id_by_type) when is_list(data) do
+    Enum.map(data, &Resource.to_params(&1, resource_by_id_by_type))
+  end
+
+  def to_params(%__MODULE__{data: resource = %Resource{}}, resource_by_id_by_type) do
+    Resource.to_params(resource, resource_by_id_by_type)
+  end
+
+  def to_params(%__MODULE__{data: nil}, _), do: %{}
 
   ## Private functions
 

--- a/lib/alembic/links.ex
+++ b/lib/alembic/links.ex
@@ -8,7 +8,6 @@ defmodule Alembic.Links do
   > </cite>
   """
 
-  alias Alembic
   alias Alembic.Document
   alias Alembic.Error
   alias Alembic.FromJson

--- a/lib/alembic/relationship.ex
+++ b/lib/alembic/relationship.ex
@@ -11,7 +11,6 @@ defmodule Alembic.Relationship do
   > </cite>
   """
 
-  alias Alembic
   alias Alembic.Document
   alias Alembic.Error
   alias Alembic.FromJson
@@ -61,8 +60,6 @@ defmodule Alembic.Relationship do
 
   # Types
 
-  @type resource_identifier :: %{String.t => String.t}
-
   @typedoc """
   > A "relationship object" **MUST** contain at least one of the following:
   >
@@ -82,9 +79,9 @@ defmodule Alembic.Relationship do
   > </cite>
   """
   @type t :: %__MODULE__{
-               data: [resource_identifier] | resource_identifier,
+               data: [ResourceIdentifier.t] | ResourceIdentifier.t,
                links: Links.links,
-               meta: Alembic.meta
+               meta: Meta.t
              }
 
   # Functions

--- a/lib/alembic/relationship.ex
+++ b/lib/alembic/relationship.ex
@@ -17,9 +17,11 @@ defmodule Alembic.Relationship do
   alias Alembic.Links
   alias Alembic.Meta
   alias Alembic.ResourceLinkage
+  alias Alembic.ToEctoSchema
   alias Alembic.ToParams
 
   @behaviour FromJson
+  @behaviour ToEctoSchema
   @behaviour ToParams
 
   # Constants
@@ -377,6 +379,163 @@ defmodule Alembic.Relationship do
         ]
       }
     }
+  end
+
+  @doc """
+  Converts `t` to [`Ecto.Schema.t`](http://hexdocs.pm/ecto/Ecto.Schema.html#t:t/0) one or more structs.
+
+  ## To-one
+
+  An empty to-one, `nil`, is `nil` when converted because there is no type information.
+
+      iex> Alembic.Relationship.to_ecto_schema(
+      ...>   %Alembic.Relationship{data: nil},
+      ...>   %{},
+      ...>   %{}
+      ...> )
+      nil
+
+  A resource identifier uses `resource_by_id_by_type` to fill in the attributes of the referenced resource.
+
+      iex> Alembic.Relationship.to_ecto_schema(
+      ...>   %Alembic.Relationship{
+      ...>     data: %Alembic.ResourceIdentifier{
+      ...>       id: "1", type: "shirt"
+      ...>     }
+      ...>   },
+      ...>   %{
+      ...>     "shirt" => %{
+      ...>       "1" => %Alembic.Resource{
+      ...>         type: "shirt",
+      ...>         id: "1",
+      ...>         attributes: %{
+      ...>           "size" => "L"
+      ...>         }
+      ...>       }
+      ...>     }
+      ...>   },
+      ...>   %{
+      ...>     "shirt" => Alembic.TestShirt
+      ...>   }
+      ...> )
+      %Alembic.TestShirt{
+        __meta__: %Ecto.Schema.Metadata{
+          source: {nil, "shirts"},
+          state: :built
+        },
+        id: 1,
+        size: "L"
+      }
+
+  On create or update, a relationship can be created by having an `Alembic.Resource.t`, in which case the
+  attributes are supplied by the `Alembic.Resource.t`, instead of `resource_by_id_by_type`.
+
+      iex> Alembic.Relationship.to_ecto_schema(
+      ...>   %Alembic.Relationship{
+      ...>     data: %Alembic.Resource{
+      ...>       attributes: %{
+      ...>         "size" => "L"
+      ...>       },
+      ...>       type: "shirt"
+      ...>     }
+      ...>   },
+      ...>   %{},
+      ...>   %{
+      ...>     "shirt" => Alembic.TestShirt
+      ...>   }
+      ...> )
+      %Alembic.TestShirt{
+        __meta__: %Ecto.Schema.Metadata{
+          source: {nil, "shirts"},
+          state: :built
+        },
+        size: "L"
+      }
+
+  ## To-many
+
+  An empty to-many, `[]`, is `[]` when converted
+
+      iex> Alembic.Relationship.to_ecto_schema(
+      ...>   %Alembic.Relationship{
+      ...>     data: []
+      ...>   },
+      ...>   %{},
+      ...>   %{}
+      ...> )
+      []
+
+  A list of resource identifiers uses `resource_by_id_by_type` to fill in the attributes of the referenced resources.
+
+      iex> Alembic.Relationship.to_ecto_schema(
+      ...>   %Alembic.Relationship{
+      ...>     data: [
+      ...>       %Alembic.ResourceIdentifier{
+      ...>         id: "1", type: "shirt"
+      ...>       }
+      ...>     ]
+      ...>   },
+      ...>   %{
+      ...>     "shirt" => %{
+      ...>       "1" => %Alembic.Resource{
+      ...>         type: "shirt",
+      ...>         id: "1",
+      ...>         attributes: %{
+      ...>           "size" => "L"
+      ...>         }
+      ...>       }
+      ...>     }
+      ...>   },
+      ...>   %{
+      ...>     "shirt" => Alembic.TestShirt
+      ...>   }
+      ...> )
+      [
+        %Alembic.TestShirt{
+          __meta__: %Ecto.Schema.Metadata{
+            source: {nil, "shirts"},
+            state: :built
+          },
+          id: 1,
+          size: "L"
+        }
+      ]
+
+  On create or update, a relationship can be created by having an `Alembic.Resource.t`, in which case the
+  attributes are supplied by the `Alembic.Resource`, instead of `resource_by_id_by_type`.
+
+      iex> Alembic.Relationship.to_ecto_schema(
+      ...>   %Alembic.Relationship{
+      ...>     data: [
+      ...>       %Alembic.Resource{
+      ...>         attributes: %{
+      ...>           "size" => "L"
+      ...>         },
+      ...>         type: "shirt"
+      ...>       }
+      ...>     ]
+      ...>   },
+      ...>   %{},
+      ...>   %{
+      ...>     "shirt" => Alembic.TestShirt
+      ...>   }
+      ...> )
+      [
+        %Alembic.TestShirt{
+          __meta__: %Ecto.Schema.Metadata{
+            source: {nil, "shirts"},
+            state: :built
+          },
+          size: "L"
+        }
+      ]
+
+  """
+  @spec to_ecto_schema(%__MODULE__{data: nil},
+                       ToParams.resource_by_id_by_type,
+                       ToEctoSchema.ecto_schema_module_by_type) :: nil | [] | struct | [struct]
+  def to_ecto_schema(%__MODULE__{data: data}, resource_by_id_by_type, ecto_schema_module_by_type) do
+    ResourceLinkage.to_ecto_schema(data, resource_by_id_by_type, ecto_schema_module_by_type)
   end
 
   @doc """

--- a/lib/alembic/relationships.ex
+++ b/lib/alembic/relationships.ex
@@ -12,14 +12,15 @@ defmodule Alembic.Relationships do
   > </cite>
   """
 
-  alias Alembic
   alias Alembic.Document
   alias Alembic.Error
   alias Alembic.FromJson
   alias Alembic.Relationship
+  alias Alembic.ToEctoSchema
   alias Alembic.ToParams
 
   @behaviour FromJson
+  @behaviour ToEctoSchema
   @behaviour ToParams
 
   # Constants
@@ -244,6 +245,125 @@ defmodule Alembic.Relationships do
         ]
       }
     }
+  end
+
+  @doc """
+  Converts relationships to map of the relationship's struct(s) that can be merged with the struct for the primary data
+
+  ## No relationships
+
+  No relationships are represented as `nil` in `IntrepreterServer.Api.Document.t`, but since the output of
+  `to_ecto_schema/2` is expected to be `struct/2` combinable with the primary resource's struct, an empty map is
+  returned when relationships is `nil`.
+
+      iex> Alembic.Relationships.to_ecto_schema(nil, %{}, %{})
+      %{}
+
+  ## Some Relationships
+
+  Relatonships are expected to be `struct/2` combinable with the primary resource's struct, so relationships are
+  returned as a map using the original relationship name and each `Alembic.Relationship.t` converted with
+  `Alembic.Relationship.to_ecto_schema/3`.
+
+  ### Resource Identifiers
+
+  If the resource linkage for a relationship is an `Alembic.ResourceIdentifier.t`, then the attributes for
+  the resource will be looked up in `resource_by_id_by_type`.
+
+      iex> Alembic.Relationships.to_ecto_schema(
+      ...>   %{
+      ...>     "author" => %Alembic.Relationship{
+      ...>       data: %Alembic.ResourceIdentifier{id: "1", type: "author"}
+      ...>     }
+      ...>   },
+      ...>   %{
+      ...>     "author" => %{
+      ...>       "1" => %Alembic.Resource{
+      ...>         type: "author",
+      ...>         id: "1",
+      ...>         attributes: %{
+      ...>           "name" => "Alice"
+      ...>         }
+      ...>       }
+      ...>     }
+      ...>   },
+      ...>   %{
+      ...>     "author" => Alembic.TestAuthor
+      ...>   }
+      ...> )
+      %{
+        "author" => %Alembic.TestAuthor{
+          __meta__: %Ecto.Schema.Metadata{
+            source: {nil, "authors"},
+            state: :built
+          },
+          id: 1,
+          name: "Alice"
+        }
+      }
+
+  Resources are not required to be in `resources_by_id_by_type`, as would be the case when only a foreign key is
+  supplied.
+
+      iex> Alembic.Relationships.to_ecto_schema(
+      ...>   %{
+      ...>     "author" => %Alembic.Relationship{
+      ...>       data: %Alembic.ResourceIdentifier{id: "1", type: "author"}
+      ...>     }
+      ...>   },
+      ...>   %{},
+      ...>   %{
+      ...>     "author" => Alembic.TestAuthor
+      ...>   }
+      ...> )
+      %{
+        "author" => %Alembic.TestAuthor{
+          __meta__: %Ecto.Schema.Metadata{
+            source: {nil, "authors"},
+            state: :built
+          },
+          id: 1
+        }
+      }
+
+  ### Resources
+
+  On create or update, the relationships can directly contain `Alembic.Resource.t` that are to be created,
+  in which case the `resource_by_id_by_type` are ignored.
+
+      iex> Alembic.Relationships.to_ecto_schema(
+      ...>   %{
+      ...>     "author" => %Alembic.Relationship{
+      ...>       data: %Alembic.Resource{
+      ...>         attributes: %{"name" => "Alice"},
+      ...>         type: "author"
+      ...>       }
+      ...>     },
+      ...>   },
+      ...>   %{},
+      ...>   %{
+      ...>     "author" => Alembic.TestAuthor
+      ...>   }
+      ...> )
+      %{
+        "author" => %Alembic.TestAuthor{
+          __meta__: %Ecto.Schema.Metadata{
+            source: {nil, "authors"},
+            state: :built
+          },
+          name: "Alice"
+        }
+      }
+  """
+
+  @spec to_ecto_schema(nil, ToParams.resource_by_id_by_type, ToEctoSchema.ecto_schema_module_by_type) :: map
+  def to_ecto_schema(nil, _, _), do: %{}
+
+  @spec to_ecto_schema(t, ToParams.resource_by_id_by_type, ToEctoSchema.ecto_schema_module_by_type) :: map
+  def to_ecto_schema(relationship_by_name, resource_by_id_by_type, ecto_schema_module_by_type) do
+    Enum.into relationship_by_name, %{}, fn {name, relationship} ->
+      {name, Relationship.to_ecto_schema(relationship, resource_by_id_by_type, ecto_schema_module_by_type)}
+    end
   end
 
   @doc """

--- a/lib/alembic/relationships.ex
+++ b/lib/alembic/relationships.ex
@@ -12,12 +12,15 @@ defmodule Alembic.Relationships do
   > </cite>
   """
 
+  alias Alembic
   alias Alembic.Document
   alias Alembic.Error
   alias Alembic.FromJson
   alias Alembic.Relationship
+  alias Alembic.ToParams
 
   @behaviour FromJson
+  @behaviour ToParams
 
   # Constants
 
@@ -241,6 +244,106 @@ defmodule Alembic.Relationships do
         ]
       }
     }
+  end
+
+  @doc """
+  Converts relationships to params format used by
+  [`Ecto.Changeset.cast/4`](http://hexdocs.pm/ecto/Ecto.Changeset.html#cast/4) that can be merged with the params
+  from the primary data.
+
+  ## No relationships
+
+  No relationships are represented as `nil` in `Alembic.Document.t`, but since the output of
+  `to_params/2` is expected to be `Map.merge/2` with the primary resource's params, an empty map is returned when
+  relationships is `nil`.
+
+      iex> Alembic.Relationships.to_params(nil, %{})
+      %{}
+
+  ## Some Relationships
+
+  Relatonship params are expected to be `Map.merge/2` with the primary resource's params, so a relationships are
+  returned as a map using the original relationship name and each `Alembic.Relationship.t` converted with
+  `Alembic.Relationship.to_params/2`.
+
+  ### Resource Identifiers
+
+  If the resource linkage for a relationship is an `Alembic.ResourceIdentifier.t`, then the attributes for
+  the resource will be looked up in `resource_by_id_by_type`.
+
+      iex> Alembic.Relationships.to_params(
+      ...>   %{
+      ...>     "author" => %Alembic.Relationship{
+      ...>       data: %Alembic.ResourceIdentifier{id: "1", type: "author"}
+      ...>     }
+      ...>   },
+      ...>   %{
+      ...>     "author" => %{
+      ...>       "1" => %Alembic.Resource{
+      ...>         type: "author",
+      ...>         id: "1",
+      ...>         attributes: %{
+      ...>           "name" => "Alice"
+      ...>         }
+      ...>       }
+      ...>     }
+      ...>   }
+      ...> )
+      %{
+        "author" => %{
+          "id" => "1",
+          "name" => "Alice"
+        }
+      }
+
+  Resources are not required to be in `resources_by_id_by_type`, as would be the case when only a foreign key is
+  supplied.
+
+      iex> Alembic.Relationships.to_params(
+      ...>   %{
+      ...>     "author" => %Alembic.Relationship{
+      ...>       data: %Alembic.ResourceIdentifier{id: "1", type: "author"}
+      ...>     }
+      ...>   },
+      ...>   %{}
+      ...> )
+      %{
+        "author" => %{
+          "id" => "1"
+        }
+      }
+
+  ### Resources
+
+  On create or update, the relationships can directly contain `Alembic.Resource.t` that are to be created,
+  in which case the `resource_by_id_by_type` are ignored.
+
+      iex> Alembic.Relationships.to_params(
+      ...>   %{
+      ...>     "author" => %Alembic.Relationship{
+      ...>       data: %Alembic.Resource{
+      ...>         attributes: %{"name" => "Alice"},
+      ...>         type: "author"
+      ...>       }
+      ...>     },
+      ...>   },
+      ...>   %{}
+      ...> )
+      %{
+        "author" => %{
+          "name" => "Alice"
+        }
+      }
+  """
+
+  @spec to_params(nil, ToParams.resource_by_id_by_type) :: %{}
+  def to_params(nil, _), do: %{}
+
+  @spec to_params(t, ToParams.resource_by_id_by_type) :: ToParams.params
+  def to_params(relationship_by_name = %{}, resource_by_id_by_type = %{}) do
+    Enum.into relationship_by_name, %{}, fn {name, relationship} ->
+      {name, Relationship.to_params(relationship, resource_by_id_by_type)}
+    end
   end
 
   ## Private Functions

--- a/lib/alembic/resource_linkage.ex
+++ b/lib/alembic/resource_linkage.ex
@@ -16,15 +16,16 @@ defmodule Alembic.ResourceLinkage do
   > </cite>
   """
 
-  alias Alembic
   alias Alembic.Document
   alias Alembic.Error
   alias Alembic.FromJson
   alias Alembic.Resource
   alias Alembic.ResourceIdentifier
+  alias Alembic.ToEctoSchema
   alias Alembic.ToParams
 
   @behaviour FromJson
+  @behaviour ToEctoSchema
   @behaviour ToParams
 
   # Constants
@@ -344,6 +345,170 @@ defmodule Alembic.ResourceLinkage do
   # Alembic.json -- [nil, [], Alembic.json_object, [Alembic.json_object]]
   @spec from_json(true | false | float | integer, Error.t) :: FromJson.error
   def from_json(_, error_template), do: type_error(error_template)
+
+  @doc """
+  Converts resource linkage to one or more [`Ecto.Schema.t`](http://hexdocs.pm/ecto/Ecto.Schema.html#t:t/0) structs.
+
+  ## To-one
+
+  An empty to-one, `nil`, is `nil` when converted to an Ecto Schema struct because no type information is available.
+
+      iex> Alembic.ResourceLinkage.to_ecto_schema(nil, %{}, %{})
+      nil
+
+  A resource identifier uses `resource_by_id_by_type` to fill in the attributes of the referenced resource. `type` is
+  dropped as [`Ecto.Changeset.cast/4`](http://hexdocs.pm/ecto/Ecto.Changeset.html#cast/4) doesn't verify types in the
+  params.
+
+      iex> Alembic.ResourceLinkage.to_ecto_schema(
+      ...>   %Alembic.ResourceIdentifier{
+      ...>     type: "shirt",
+      ...>     id: "1"
+      ...>   },
+      ...>   %{
+      ...>     "shirt" => %{
+      ...>       "1" => %Alembic.Resource{
+      ...>         type: "shirt",
+      ...>         id: "1",
+      ...>         attributes: %{
+      ...>           "size" => "L"
+      ...>         }
+      ...>       }
+      ...>     }
+      ...>   },
+      ...>   %{
+      ...>     "shirt" => Alembic.TestShirt
+      ...>   }
+      ...> )
+      %Alembic.TestShirt{
+        __meta__: %Ecto.Schema.Metadata{
+          source: {nil, "shirts"},
+          state: :built
+        },
+        id: 1,
+        size: "L"
+      }
+
+  On create or update, a relationship can be created by having an `Alembic.Resource.t`, in which case the
+  attributes are supplied by the `Alembic.Resource.t`, instead of `resource_by_id_by_type`.
+
+      iex> Alembic.ResourceLinkage.to_ecto_schema(
+      ...>   %Alembic.Resource{
+      ...>     attributes: %{
+      ...>       "size" => "L"
+      ...>     },
+      ...>     type: "shirt"
+      ...>   },
+      ...>   %{},
+      ...>   %{
+      ...>     "shirt" => Alembic.TestShirt
+      ...>   }
+      ...> )
+      %Alembic.TestShirt{
+        __meta__: %Ecto.Schema.Metadata{
+          source: {nil, "shirts"},
+          state: :built
+        },
+        size: "L"
+      }
+
+  ## To-many
+
+  An empty to-many, `[]`, is `[]` when converted because there is no type information available
+
+      iex> Alembic.ResourceLinkage.to_ecto_schema(
+      ...>   [],
+      ...>   %{},
+      ...>   %{}
+      ...> )
+      []
+
+  A list of resource identifiers uses `resources_by_id_by_type` to fill in the attributes of the referenced resources.
+
+      iex> Alembic.ResourceLinkage.to_ecto_schema(
+      ...>   [
+      ...>     %Alembic.ResourceIdentifier{
+      ...>       type: "shirt",
+      ...>       id: "1"
+      ...>     }
+      ...>   ],
+      ...>   %{
+      ...>     "shirt" => %{
+      ...>       "1" => %Alembic.Resource{
+      ...>         type: "shirt",
+      ...>         id: "1",
+      ...>         attributes: %{
+      ...>           "size" => "L"
+      ...>         }
+      ...>       }
+      ...>     }
+      ...>   },
+      ...>   %{
+      ...>     "shirt" => Alembic.TestShirt
+      ...>   }
+      ...> )
+      [
+        %Alembic.TestShirt{
+          __meta__: %Ecto.Schema.Metadata{
+            source: {nil, "shirts"},
+            state: :built
+          },
+          id: 1,
+          size: "L"
+        }
+      ]
+
+  On create or update, a relationship can be created by having an `Alembic.Resource`, in which case the
+  attributes are supplied by the `Alembic.Resource`, instead of `resource_by_id_by_type`.
+
+      iex> Alembic.ResourceLinkage.to_ecto_schema(
+      ...>   [
+      ...>     %Alembic.Resource{
+      ...>       attributes: %{
+      ...>         "size" => "L"
+      ...>       },
+      ...>       type: "shirt"
+      ...>     }
+      ...>   ],
+      ...>   %{},
+      ...>   %{
+      ...>     "shirt" => Alembic.TestShirt
+      ...>   }
+      ...> )
+      [
+        %Alembic.TestShirt{
+          __meta__: %Ecto.Schema.Metadata{
+            source: {nil, "shirts"},
+            state: :built
+          },
+          id: nil,
+          size: "L"
+        }
+      ]
+
+  """
+
+  @spec to_ecto_schema(nil, ToParams.resource_by_id_by_type, ToEctoSchema.ecto_schema_module_by_type) :: nil
+  def to_ecto_schema(nil, _, _), do: nil
+
+  @spec to_ecto_schema([Resource.t] | [ResourceIdentifier.t],
+                       ToParams.resource_by_id_by_type,
+                       ToEctoSchema.ecto_schema_module_by_type) :: [struct]
+  def to_ecto_schema(list, resource_by_id_by_type, ecto_schema_module_by_type) when is_list(list) do
+    Enum.map list, &to_ecto_schema(&1, resource_by_id_by_type, ecto_schema_module_by_type)
+  end
+
+  @spec to_ecto_schema(Resource.t | ResourceIdentifier.t,
+                       ToParams.resource_by_id_by_type,
+                       ToEctoSchema.ecto_schema_module_by_type) :: struct
+
+  def to_ecto_schema(resource_identifier = %ResourceIdentifier{}, resource_by_id_by_type, ecto_schema_module_by_type) do
+    ResourceIdentifier.to_ecto_schema(resource_identifier, resource_by_id_by_type, ecto_schema_module_by_type)
+  end
+
+  def to_ecto_schema(resource = %Resource{}, resource_by_id_by_type, ecto_schema_module_by_type) do
+    Resource.to_ecto_schema(resource, resource_by_id_by_type, ecto_schema_module_by_type)
+  end
 
   @doc """
   Converts resource linkage to params format used by

--- a/lib/alembic/resource_linkage.ex
+++ b/lib/alembic/resource_linkage.ex
@@ -16,13 +16,16 @@ defmodule Alembic.ResourceLinkage do
   > </cite>
   """
 
+  alias Alembic
   alias Alembic.Document
   alias Alembic.Error
   alias Alembic.FromJson
   alias Alembic.Resource
   alias Alembic.ResourceIdentifier
+  alias Alembic.ToParams
 
   @behaviour FromJson
+  @behaviour ToParams
 
   # Constants
 
@@ -341,6 +344,134 @@ defmodule Alembic.ResourceLinkage do
   # Alembic.json -- [nil, [], Alembic.json_object, [Alembic.json_object]]
   @spec from_json(true | false | float | integer, Error.t) :: FromJson.error
   def from_json(_, error_template), do: type_error(error_template)
+
+  @doc """
+  Converts resource linkage to params format used by
+  [`Ecto.Changeset.cast/4`](http://hexdocs.pm/ecto/Ecto.Changeset.html#cast/4).
+
+  ## To-one
+
+  An empty to-one, `nil`, is `nil` when converted to params.
+
+      iex> Alembic.ResourceLinkage.to_params(nil, %{})
+      nil
+
+  A resource identifier uses `resource_by_id_by_type` to fill in the attributes of the referenced resource. `type` is
+  dropped as [`Ecto.Changeset.cast/4`](http://hexdocs.pm/ecto/Ecto.Changeset.html#cast/4) doesn't verify types in the
+  params.
+
+      iex> Alembic.ResourceLinkage.to_params(
+      ...>   %Alembic.ResourceIdentifier{
+      ...>     type: "shirt",
+      ...>     id: "1"
+      ...>   },
+      ...>   %{
+      ...>     "shirt" => %{
+      ...>       "1" => %Alembic.Resource{
+      ...>         type: "shirt",
+      ...>         id: "1",
+      ...>         attributes: %{
+      ...>           "size" => "L"
+      ...>         }
+      ...>       }
+      ...>     }
+      ...>   }
+      ...> )
+      %{
+        "id" => "1",
+        "size" => "L"
+      }
+
+  On create or update, a relationship can be created by having an `Alembic.Resource.t`, in which case the
+  attributes are supplied by the `Alembic.Resource.t`, instead of `resource_by_id_by_type`.
+
+      iex> Alembic.ResourceLinkage.to_params(
+      ...>   %Alembic.Resource{
+      ...>     attributes: %{
+      ...>       "size" => "L"
+      ...>     },
+      ...>     type: "shirt"
+      ...>   },
+      ...>   %{}
+      ...> )
+      %{
+        "size" => "L"
+      }
+
+  ## To-many
+
+  An empty to-many, `[]`, is `[]` when converted to params
+
+      iex> Alembic.ResourceLinkage.to_params([], %{})
+      []
+
+  A list of resource identifiers uses `attributes_by_id_by_type` to fill in the attributes of the referenced resources.
+  `type` is dropped as [`Ecto.Changeset.cast/4`](http://hexdocs.pm/ecto/Ecto.Changeset.html#cast/4) doesn't verify types
+  in the params.
+
+      iex> Alembic.ResourceLinkage.to_params(
+      ...>   [
+      ...>     %Alembic.ResourceIdentifier{
+      ...>       type: "shirt",
+      ...>       id: "1"
+      ...>     }
+      ...>   ],
+      ...>   %{
+      ...>     "shirt" => %{
+      ...>       "1" => %Alembic.Resource{
+      ...>         type: "shirt",
+      ...>         id: "1",
+      ...>         attributes: %{
+      ...>           "size" => "L"
+      ...>         }
+      ...>       }
+      ...>     }
+      ...>  }
+      ...> )
+      [
+        %{
+          "id" => "1",
+          "size" => "L"
+        }
+      ]
+
+  On create or update, a relationship can be created by having an `Alembic.Resource`, in which case the
+  attributes are supplied by the `Alembic.Resource`, instead of `attributes_by_id_by_type`.
+
+      iex> Alembic.ResourceLinkage.to_params(
+      ...>   [
+      ...>     %Alembic.Resource{
+      ...>       attributes: %{
+      ...>         "size" => "L"
+      ...>       },
+      ...>       type: "shirt"
+      ...>     }
+      ...>   ],
+      ...>   %{}
+      ...> )
+      [
+        %{
+          "size" => "L"
+        }
+      ]
+
+  """
+  @spec to_params([Resource.t | ResourceIdentifier.t] | Resource.t | ResourceIdentifier.t | nil,
+                  ToParams.resource_by_id_by_type) :: ToParams.params
+
+  def to_params(nil, %{}), do: nil
+
+  def to_params(list, resource_by_id_by_type) when is_list(list) do
+    Enum.map list, &to_params(&1, resource_by_id_by_type)
+  end
+
+  def to_params(resource = %Resource{}, resource_by_id_by_type) do
+    Resource.to_params(resource, resource_by_id_by_type)
+  end
+
+  def to_params(resource_identifier = %ResourceIdentifier{}, resource_by_id_by_type) do
+    ResourceIdentifier.to_params(resource_identifier, resource_by_id_by_type)
+  end
 
   ## Private Functions
 

--- a/lib/alembic/to_ecto_schema.ex
+++ b/lib/alembic/to_ecto_schema.ex
@@ -1,0 +1,62 @@
+defmodule Alembic.ToEctoSchema do
+  @moduledoc """
+  The `Alembic.ToEctoSchema` behaviour converts a struct in the `Alembic` namespace to
+  an `Ecto.Schema.t` struct.
+  """
+
+  alias Alembic.Resource
+  alias Alembic.ToParams
+
+  # Types
+
+  @typedoc """
+  * `nil` if an empty singleton
+  * `struct` - if a non-empty singleton
+  * `[]` - if an empty collection
+  * `[struct]` - if a non-empty collection
+  """
+  @type ecto_schema :: nil | struct | [] | [struct, ...]
+
+  @typedoc """
+  A module that defines `__struct__/0` and `__schema__(:fields)` as happens when `use Ecto.Schema` is run in a module.
+  """
+  @type ecto_schema_module :: atom
+
+  @typedoc """
+  Maps JSON API `Alembic.Resource.type` to `ecto_schema_module` for casting that
+  `Alembic.Resource.type`.
+  """
+  @type ecto_schema_module_by_type :: %{Resource.type => ecto_schema_module}
+
+  @doc """
+  ## Parameters
+
+  * `struct` - an `Alembic.Document.t` hierarchy struct
+  * `attributes_by_id_by_type` - Maps a resource identifier's `Alembic.ResourceIdentifier.type` and
+    `Alembic.ResourceIdentifier.id` to its `Alembic.Resource.attributes` from
+    `Alembic.Document.t` `included`.
+  * `ecto_schema_module_by_type` -
+
+  ## Returns
+
+  * `nil` if an empty singleton
+  * `struct` - if a non-empty singleton
+  * `[]` - if an empty collection
+  * `[struct]` - if a non-empty collection
+  """
+  @callback to_ecto_schema(struct, ToParams.resource_by_id_by_type, ecto_schema_module_by_type) :: ecto_schema
+
+  @spec to_ecto_schema(ToParams.params, ecto_schema_module) :: struct
+  # prefer to keep Ecto.Changeset instead of Changeset
+  @lint {Credo.Check.Design.AliasUsage, false}
+  def to_ecto_schema(params, ecto_schema_module) when is_atom(ecto_schema_module) do
+    changeset = Ecto.Changeset.cast(ecto_schema_module.__struct__, params, ecto_schema_module.__schema__(:fields))
+    struct(ecto_schema_module, changeset.changes)
+  end
+
+  @spec to_ecto_schema(%{type: Resource.type}, ToParams.params, ecto_schema_module_by_type) :: struct
+  def to_ecto_schema(%{type: type}, params, ecto_schema_module_by_type) do
+    ecto_schema_module = Map.fetch!(ecto_schema_module_by_type, type)
+    to_ecto_schema(params, ecto_schema_module)
+  end
+end

--- a/lib/alembic/to_params.ex
+++ b/lib/alembic/to_params.ex
@@ -1,0 +1,38 @@
+defmodule Alembic.ToParams do
+  @moduledoc """
+  The `Alembic.ToParams` behaviour converts a data structure in the `Alembic` namespace to
+  the params format used by [`Ecto.Changeset.cast/4`](http://hexdocs.pm/ecto/Ecto.Changeset.html#cast/4).
+  """
+
+  # Types
+
+  @typedoc """
+  Params format used by [`Ecto.Changeset.cast/4`](http://hexdocs.pm/ecto/Ecto.Changeset.html#cast/4).
+  """
+  @type params :: list | map | nil
+
+  @typedoc """
+  A nest map with the outer layer keyed by the `Alembic.Resource.type`, then the next layer keyed by the
+  `Alembic.Resource.id` with the values being the full `Alembic.Resource.t`
+  """
+  @type resource_by_id_by_type :: %{Resource.type => %{Resource.id => Resource.t}}
+
+  # Callbacks
+
+  @doc """
+  ## Parameters
+
+  * `any` - an `Alembic.Document.t` hierarchy data structure
+  * `resources_by_id_by_type` - A nest map with the outer layer keyed by the `Alembic.Resource.type`,
+    then the next layer keyed by the `Alembic.Resource.id` with the values being the full
+    `Alembic.Resource.t` from `Alembic.Document.t` `included`.
+
+  ## Returns
+
+  * `nil` if an empty singleton
+  * `%{}` - if a non-empty singleton
+  * `[]` - if an empty collection
+  * `[%{}]` - if a non-empty collection
+  """
+  @callback to_params(any, resource_by_id_by_type) :: params
+end

--- a/mix.exs
+++ b/mix.exs
@@ -49,6 +49,8 @@ defmodule Alembic.Mixfile do
       {:dialyze, "~> 0.2.1", only: [:dev, :test]},
       # markdown to HTML converter for ex_doc
       {:earmark, "~> 0.2.1", only: :dev},
+      # conversion to Ecto.Schema struct
+      {:ecto, "~> 1.0"},
       # documentation generation
       {:ex_doc, "~> 0.11.5", only: :dev},
       # documentation coverage

--- a/mix.lock
+++ b/mix.lock
@@ -2,8 +2,10 @@
   "certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
   "coverex": {:hex, :coverex, "1.4.9", "5f923d9fa5d50cf0eea40a55940cfc7dbf73138fb4dbab565c54d7f2e8724722", [:mix], [{:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}, {:httpoison, "~> 0.8", [hex: :httpoison, optional: false]}]},
   "credo": {:hex, :credo, "0.3.13", "90d2d2deb9d376bb2a63f81126a320c3920ce65acb1294982ab49a8aacc7d89f", [:mix], [{:bunt, "~> 0.1.4", [hex: :bunt, optional: false]}]},
+  "decimal": {:hex, :decimal, "1.1.2", "79a769d4657b2d537b51ef3c02d29ab7141d2b486b516c109642d453ee08e00c", [:mix], []},
   "dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [:mix], []},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "ecto": {:hex, :ecto, "1.1.7", "c37127248756e725eb8254b371764b40c05a90c104b2065d1d4f7e32573fdbec", [:mix], [{:sbroker, "~> 0.7", [hex: :sbroker, optional: true]}, {:postgrex, "~> 0.11.0", [hex: :postgrex, optional: true]}, {:poolboy, "~> 1.4", [hex: :poolboy, optional: false]}, {:poison, "~> 1.0 or ~> 2.0", [hex: :poison, optional: true]}, {:mariaex, "~> 0.5.0 or ~> 0.6.0", [hex: :mariaex, optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
   "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
   "hackney": {:hex, :hackney, "1.6.0", "8d1e9440c9edf23bf5e5e2fe0c71de03eb265103b72901337394c840eec679ac", [:rebar3], [{:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:certifi, "0.4.0", [hex: :certifi, optional: false]}]},
   "httpoison": {:hex, :httpoison, "0.8.3", "b675a3fdc839a0b8d7a285c6b3747d6d596ae70b6ccb762233a990d7289ccae4", [:mix], [{:hackney, "~> 1.6.0", [hex: :hackney, optional: false]}]},
@@ -13,4 +15,5 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []}}

--- a/test/support/api/test_author.ex
+++ b/test/support/api/test_author.ex
@@ -1,0 +1,13 @@
+defmodule Alembic.TestAuthor do
+  @moduledoc """
+  A schema used in examples in `Alembic`
+  """
+
+  use Ecto.Schema
+
+  schema "authors" do
+    field :name, :string
+
+    has_many :posts, Alembic.TestPost, foreign_key: :author_id
+  end
+end

--- a/test/support/api/test_comment.ex
+++ b/test/support/api/test_comment.ex
@@ -1,0 +1,13 @@
+defmodule Alembic.TestComment do
+  @moduledoc """
+  A schema used in examples in `Alembic`
+  """
+
+  use Ecto.Schema
+
+  schema "comments" do
+    field :text, :string
+
+    belongs_to :post, Alembic.TestPost
+  end
+end

--- a/test/support/api/test_post.ex
+++ b/test/support/api/test_post.ex
@@ -1,0 +1,14 @@
+defmodule Alembic.TestPost do
+  @moduledoc """
+  A schema used in examples in `Alembic`
+  """
+
+  use Ecto.Schema
+
+  schema "posts" do
+    field :text, :string
+
+    belongs_to :author, Alembic.TestAuthor
+    has_many :comments, Alembic.TestComment
+  end
+end

--- a/test/support/api/test_shirt.ex
+++ b/test/support/api/test_shirt.ex
@@ -1,0 +1,11 @@
+defmodule Alembic.TestShirt do
+  @moduledoc """
+  A schema used in examples in `Alembic`
+  """
+
+  use Ecto.Schema
+
+  schema "shirts" do
+    field :size, :string
+  end
+end

--- a/test/support/api/test_thing.ex
+++ b/test/support/api/test_thing.ex
@@ -1,0 +1,13 @@
+defmodule Alembic.TestThing do
+  @moduledoc """
+  A schema used in examples in `Alembic`
+  """
+
+  use Ecto.Schema
+
+  schema "things" do
+    field :name, :string
+
+    belongs_to :shirt, Alembic.TestShirt
+  end
+end


### PR DESCRIPTION
# Changelog

## Enhancements
* `Alembic.Document.to_params/1` takes an `Alembic.Document.t` and converts it to the params format used by `Ecto.Changset.cast/4`
* `Alembic.Document.to_ecto_schema/2` takes an `Alembic.Document.t` and converts it to `Ecto.Schema` structs that an be used in the rest of an application.

## Bug Fixes
* Use `Alembic.ResourceIdentifier.t` in `Alembic.Relationship.t` for `data`'s value type.
* Use `Alembic.Meta.t` in `Alembic.Relationship.t` for `meta`'s value type.

## Incompatible Changes
* Removed the `Alembic.Relationship.resource_identifier` type that was made obsolete by `Alembic.ResourceIdentifier.t`
* Updating relations by nesting attributes is no longer supported as it is not supported in the JSONAPI spec.