### PR TITLE
Bug fixes based on real-world usage

### DIFF
--- a/lib/alembic/resource.ex
+++ b/lib/alembic/resource.ex
@@ -995,11 +995,13 @@ defmodule Alembic.Resource do
 
   def to_params(%__MODULE__{attributes: attributes, id: id, relationships: relationships},
                 resource_by_id_by_type = %{}) do
+    params = attributes || %{}
+
     params = case id do
       nil ->
-        attributes
+        params
       _ ->
-        Map.put(attributes, "id", id)
+        Map.put(params, "id", id)
     end
 
     Map.merge(params, Relationships.to_params(relationships, resource_by_id_by_type))


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Use `:unset` instead of `nil` for unset `%Alembic.Document{}` `data` as it was too difficult to properly infer when `nil` was unset and when it was a singleton that was not present.
* `Alembic.Resource.to_params` now treats `nil` `%Alembic.Resource{}` `attributes` as `%{}` when building the params so invalid input from user does not cause an exception.
