### PR TITLE
Allow jsonapi field in Document.t

### DIFF
--- a/lib/alembic/document.ex
+++ b/lib/alembic/document.ex
@@ -77,6 +77,7 @@ defmodule Alembic.Document do
   defstruct data: :unset,
             errors: nil,
             included: nil,
+            jsonapi: nil,
             links: nil,
             meta: nil
 
@@ -1552,6 +1553,20 @@ defmodule Alembic.Document do
         ...>   }
         ...> )
         {:ok, "{\\"errors\\":[{\\"source\\":{\\"pointer\\":\\"\\"}}]}"}
+
+    ## JSONAPI
+
+    The JSONAPI version information can be set in the document and it will be encoded
+
+        iex> Poison.encode(
+        ...>   %Alembic.Document{
+        ...>     jsonapi: %{
+        ...>       "version" => "1.0"
+        ...>     },
+        ...>     data: nil
+        ...>   }
+        ...> )
+        {:ok, "{\\"jsonapi\\":{\\"version\\":\\"1.0\\"},\\"data\\":null}"}
 
     ## Meta
 

--- a/test/poison/encoder/alembic/resource_identifier_test.exs
+++ b/test/poison/encoder/alembic/resource_identifier_test.exs
@@ -1,0 +1,8 @@
+defmodule Poison.Encoder.Alembic.ResourceIdentifierTest do
+  @moduledoc """
+  Runs doctests for `Poison.Encoder` implementation for `Alembic.ResourceIdentifier`
+  """
+  use ExUnit.Case, async: true
+
+  doctest Poison.Encoder.Alembic.ResourceIdentifier
+end


### PR DESCRIPTION
# Changelog

## Enhancements
* Allow `jsonapi` field in `Document.t`, so that jsonapi can be set to `%{ "version" => "1.0" }` to match `JaSerializer` output.

## Bug Fixes
* Don't encode `ResourceIdentifier.meta` when it is `nil`, so that `"meta":null` doesn't occur in the encoded version.