### PR TITLE
Pagination

### DIFF
--- a/lib/alembic/document.ex
+++ b/lib/alembic/document.ex
@@ -7,6 +7,7 @@ defmodule Alembic.Document do
   alias Alembic.FromJson
   alias Alembic.Links
   alias Alembic.Meta
+  alias Alembic.Pagination
   alias Alembic.Resource
   alias Alembic.ResourceLinkage
   alias Alembic.ToEctoSchema
@@ -17,6 +18,7 @@ defmodule Alembic.Document do
   @behaviour FromJson
   @behaviour ToEctoSchema
   @behaviour ToParams
+  @behaviour Pagination
 
   # Constants
 
@@ -1230,6 +1232,160 @@ defmodule Alembic.Document do
                      ecto_schema_module_by_type) when is_list(resources) do
     Enum.map resources, &Resource.to_ecto_schema(&1, resource_by_id_by_type, ecto_schema_module_by_type)
   end
+
+  @doc """
+  Extract paged pagination information.
+
+  To support pagination, a document at minimum must have a `"record_count"` `meta` entry.
+
+      iex> Alembic.Document.to_pagination(
+      ...>   %Alembic.Document{meta: %{ "record_count" => 10 }}
+      ...> )
+      %Alembic.Pagination{ total_size: 10 }
+
+  Without it, the `"record_count"` `meta` entry, the pagination will be `nil`
+
+      iex> Alembic.Document.to_pagination(%Alembic.Document{})
+      nil
+
+
+  ## Single Page
+
+  When there is only one page, there will be a `"first"` and `"last"` link pointing to the same page, but no
+  "next" or "prev" links.  The `total_size` as given by the `meta` `"record_count"` will between `0` and
+  the page size because the last is not necessarily full.
+
+      iex> Alembic.Document.to_pagination(
+      ...>   %Alembic.Document{
+      ...>     links: %{
+      ...>       "first" => "https://example.com/api/v1/users?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+      ...>       "last" => "https://example.com/api/v1/users?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+      ...>     },
+      ...>     meta: %{ "record_count" => 5 }
+      ...>   }
+      ...> )
+      %Alembic.Pagination{
+        first: %Alembic.Pagination.Page{
+          number: 1,
+          size: 10
+        },
+        last: %Alembic.Pagination.Page{
+          number: 1,
+          size: 10
+        },
+        total_size: 5
+      }
+
+  ## Multiple Pages
+
+  When there are multiple pages, every page will have a `"first"` and `"last"` link pointing to the respective,
+  different pages.  The `total_size` as given by the `meta` `"record_count"` will be between
+  `(last.number - 1)  * last.size` and  `last.number * last.size` because the last page is not necessarily full.
+
+  On the first page, the `"next"` link will be set, but not the `"prev"` link.
+
+      iex> Alembic.Document.to_pagination(
+      ...>   %Alembic.Document{
+      ...>     links: %{
+      ...>       "first" => "https://example.com/api/v1/users?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+      ...>       "last" => "https://example.com/api/v1/users?page%5Bnumber%5D=3&page%5Bsize%5D=10",
+      ...>       "next" => "https://example.com/api/v1/users?page%5Bnumber%5D=2&page%5Bsize%5D=10"
+      ...>     },
+      ...>     meta: %{ "record_count" => 25 }
+      ...>   }
+      ...> )
+      %Alembic.Pagination{
+        first: %Alembic.Pagination.Page{
+          number: 1,
+          size: 10
+        },
+        last: %Alembic.Pagination.Page{
+          number: 3,
+          size: 10
+        },
+        next: %Alembic.Pagination.Page{
+          number: 2,
+          size: 10
+        },
+        total_size: 25
+      }
+
+  On any middle page, both the `"next"` and `"prev"` links will be set.
+
+      iex> Alembic.Document.to_pagination(
+      ...>   %Alembic.Document{
+      ...>     links: %{
+      ...>       "first" => "https://example.com/api/v1/users?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+      ...>       "last" => "https://example.com/api/v1/users?page%5Bnumber%5D=3&page%5Bsize%5D=10",
+      ...>       "next" => "https://example.com/api/v1/users?page%5Bnumber%5D=3&page%5Bsize%5D=10",
+      ...>       "prev" => "https://example.com/api/v1/users?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+      ...>     },
+      ...>     meta: %{ "record_count" => 25 }
+      ...>   }
+      ...> )
+      %Alembic.Pagination{
+        first: %Alembic.Pagination.Page{
+          number: 1,
+          size: 10
+        },
+        last: %Alembic.Pagination.Page{
+          number: 3,
+          size: 10
+        },
+        next: %Alembic.Pagination.Page{
+          number: 3,
+          size: 10
+        },
+        previous: %Alembic.Pagination.Page{
+          number: 1,
+          size: 10
+        },
+        total_size: 25
+      }
+
+  On the last page, the `"prev"` link will be set, but not the `"next"` link.
+
+      iex> Alembic.Document.to_pagination(
+      ...>   %Alembic.Document{
+      ...>     links: %{
+      ...>       "first" => "https://example.com/api/v1/users?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+      ...>       "last" => "https://example.com/api/v1/users?page%5Bnumber%5D=3&page%5Bsize%5D=10",
+      ...>       "prev" => "https://example.com/api/v1/users?page%5Bnumber%5D=2&page%5Bsize%5D=10"
+      ...>     },
+      ...>     meta: %{ "record_count" => 25 }
+      ...>   }
+      ...> )
+      %Alembic.Pagination{
+        first: %Alembic.Pagination.Page{
+          number: 1,
+          size: 10
+        },
+        last: %Alembic.Pagination.Page{
+          number: 3,
+          size: 10
+        },
+        previous: %Alembic.Pagination.Page{
+          number: 2,
+          size: 10
+        },
+        total_size: 25
+      }
+
+  """
+  @spec to_pagination(t) :: Pagination.t | nil
+
+  def to_pagination(%__MODULE__{links: links, meta: %{"record_count" => total_size}}) do
+    document_pagination = %Pagination{total_size: total_size}
+
+    case Links.to_pagination(links) do
+      nil ->
+        document_pagination
+      %Pagination{first: first, last: last, next: next, previous: previous} ->
+        %{document_pagination | first: first, last: last, next: next, previous: previous}
+    end
+  end
+
+  def to_pagination(%__MODULE__{}), do: nil
 
   @doc """
   Transforms a `t` into the nested params format used by

--- a/lib/alembic/link.ex
+++ b/lib/alembic/link.ex
@@ -284,10 +284,10 @@ defmodule Alembic.Link do
   ## Private Functions
 
   @spec href_from_json(nil, Error.t) :: {:ok, nil}
-  def href_from_json(nil, _), do: {:ok, nil}
+  defp href_from_json(nil, _), do: {:ok, nil}
 
   @spec href_from_json(String.t, Error.t) :: {:ok, String.t}
   # Alembic.json -- [nil, String.t]
   @spec href_from_json(true | false | list | float | integer | Alembic.json_object, Error.t) :: FromJson.error
-  def href_from_json(href, error_template), do: FromJson.string_from_json(href, error_template)
+  defp href_from_json(href, error_template), do: FromJson.string_from_json(href, error_template)
 end

--- a/lib/alembic/link.ex
+++ b/lib/alembic/link.ex
@@ -8,6 +8,7 @@ defmodule Alembic.Link do
   alias Alembic.Error
   alias Alembic.FromJson
   alias Alembic.Meta
+  alias Alembic.Pagination.Page
 
   # Behaviours
 
@@ -279,6 +280,35 @@ defmodule Alembic.Link do
         ]
       }
     }
+  end
+
+  @doc """
+  Extracts `Alembic.Pagination.Page.t` `number` from `url` `"page[number]"` and `size` from `url`
+  `"page[size]"`.
+
+      iex> Alembic.Link.to_page("https://example.com/api/v1/users?page%5Bnumber%5D=2&page%5Bsize%5D=10")
+      %Alembic.Pagination.Page{number: 2, size: 10}
+
+  If a `url` does not have both `"page[number]"` and `"page[size]"` then `nil` is returned
+
+      iex> Alembic.Link.to_page("https://example.com/api/v1/users?page%5Bnumber%5D=2")
+      nil
+      iex> Alembic.Link.to_page("https://example.com/api/v1/users?page%5Bsize%5D=10")
+      nil
+      iex> Alembic.Link.to_page("https://example.com/api/v1/users?q=")
+      nil
+
+  If a `url` does not have a query then `nil` is returned
+
+      iex> Alembic.Link.to_page("https://example.com/api/v1/users")
+      nil
+
+  """
+  @spec to_page(link) :: Page.t
+  def to_page(url) when is_binary(url) do
+    url
+    |> URI.parse
+    |> Page.from_uri
   end
 
   ## Private Functions

--- a/lib/alembic/links.ex
+++ b/lib/alembic/links.ex
@@ -12,14 +12,22 @@ defmodule Alembic.Links do
   alias Alembic.Error
   alias Alembic.FromJson
   alias Alembic.Link
+  alias Alembic.Pagination
 
   # Behaviours
 
   @behaviour FromJson
+  @behaviour Pagination
 
   # Constants
 
   @human_type "links object"
+  @pagination_field_by_key %{
+    "first" => :first,
+    "last" => :last,
+    "next" => :next,
+    "prev" => :previous
+  }
 
   # Types
 
@@ -206,7 +214,155 @@ defmodule Alembic.Links do
     }
   end
 
+  @doc """
+  Converts the links to `Alembic.Pagination.t` page fields
+
+  ## Single Page
+
+  When there is only one page, there will be a `"first"` and `"last"` link pointing to the same page, but no
+  "next" or "prev" links.
+
+      iex> Alembic.Links.to_pagination(
+      ...>   %{
+      ...>     "first" => "https://example.com/api/v1/users?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+      ...>     "last" => "https://example.com/api/v1/users?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+      ...>   }
+      ...> )
+      %Alembic.Pagination{
+        first: %Alembic.Pagination.Page{
+          number: 1,
+          size: 10
+        },
+        last: %Alembic.Pagination.Page{
+          number: 1,
+          size: 10
+        }
+      }
+
+  ## Multiple Pages
+
+  When there are multiple pages, every page will have a `"first"` and `"last"` link pointing to the respective,
+  different pages.
+
+  On the first page, the `"next"` link will be set, but not the `"prev"` link.
+
+      iex> Alembic.Links.to_pagination(
+      ...>   %{
+      ...>     "first" => "https://example.com/api/v1/users?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+      ...>     "last" => "https://example.com/api/v1/users?page%5Bnumber%5D=3&page%5Bsize%5D=10",
+      ...>     "next" => "https://example.com/api/v1/users?page%5Bnumber%5D=2&page%5Bsize%5D=10"
+      ...>   }
+      ...> )
+      %Alembic.Pagination{
+        first: %Alembic.Pagination.Page{
+          number: 1,
+          size: 10
+        },
+        last: %Alembic.Pagination.Page{
+          number: 3,
+          size: 10
+        },
+        next: %Alembic.Pagination.Page{
+          number: 2,
+          size: 10
+        }
+      }
+
+  On any middle page, both the `"next"` and `"prev"` links will be set.
+
+      iex> Alembic.Links.to_pagination(
+      ...>   %{
+      ...>     "first" => "https://example.com/api/v1/users?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+      ...>     "last" => "https://example.com/api/v1/users?page%5Bnumber%5D=3&page%5Bsize%5D=10",
+      ...>     "next" => "https://example.com/api/v1/users?page%5Bnumber%5D=3&page%5Bsize%5D=10",
+      ...>     "prev" => "https://example.com/api/v1/users?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+      ...>   }
+      ...> )
+      %Alembic.Pagination{
+        first: %Alembic.Pagination.Page{
+          number: 1,
+          size: 10
+        },
+        last: %Alembic.Pagination.Page{
+          number: 3,
+          size: 10
+        },
+        next: %Alembic.Pagination.Page{
+          number: 3,
+          size: 10
+        },
+        previous: %Alembic.Pagination.Page{
+          number: 1,
+          size: 10
+        }
+      }
+
+  On the last page, the `"prev"` link will be set, but not the `"next"` link.
+
+      iex> Alembic.Links.to_pagination(
+      ...>   %{
+      ...>     "first" => "https://example.com/api/v1/users?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+      ...>     "last" => "https://example.com/api/v1/users?page%5Bnumber%5D=3&page%5Bsize%5D=10",
+      ...>     "prev" => "https://example.com/api/v1/users?page%5Bnumber%5D=2&page%5Bsize%5D=10"
+      ...>   }
+      ...> )
+      %Alembic.Pagination{
+        first: %Alembic.Pagination.Page{
+          number: 1,
+          size: 10
+        },
+        last: %Alembic.Pagination.Page{
+          number: 3,
+          size: 10
+        },
+        previous: %Alembic.Pagination.Page{
+          number: 2,
+          size: 10
+        }
+      }
+
+  ## No Links
+
+  If there are no links, then `nil` will be returned
+
+      iex> Alembic.Links.to_pagination(nil)
+      nil
+
+  ## No pagination links
+
+  If there are links, but not for pagination, then `nil` will be returned
+
+      iex> Alembic.Links.to_pagination(%{ "about" => "https://example.com/about" })
+      nil
+
+  """
+  def to_pagination(links)
+
+  @spec to_pagination(nil) :: nil
+  def to_pagination(nil), do: nil
+
+  @spec to_pagination(t) :: Pagination.t
+  def to_pagination(links) when is_map(links) do
+    reduced = Enum.reduce(@pagination_field_by_key, %Pagination{}, &reduce_links_key_field_to_pagination(links, &1, &2))
+
+    case reduced do
+      %Pagination{first: nil, last: nil, next: nil, previous: nil} ->
+        nil
+      pagination ->
+        pagination
+    end
+  end
+
   ## Private Functions
+
+  defp reduce_links_key_field_to_pagination(links, {key, field}, acc = %Pagination{}) when is_map(links) do
+    case Map.fetch(links, key) do
+      {:ok, link} ->
+        %{acc | field => Link.to_page(link)}
+      :error ->
+        acc
+    end
+  end
 
   defp validate_link_pair({key, value_json}, collectable_result, error_template) do
     key_error_template = Error.descend(error_template, key)

--- a/lib/alembic/pagination.ex
+++ b/lib/alembic/pagination.ex
@@ -1,0 +1,35 @@
+defmodule Alembic.Pagination do
+  @moduledoc """
+  Pagination by fixed-size pages
+  """
+
+  alias InterpreterServer.Api.Pagination.Page
+
+  # Struct
+
+  defstruct ~w(first last next previous total_size)a
+
+  # Types
+
+  @typedoc """
+  * `first` - the first `Page.t`
+  * `last` - the last `Page.t`
+  * `next` - the next `Page.t`
+  * `previous` - the previous `Page.t`
+  * `total_size` - the total number of all resources that can be paged.
+  """
+  @type t :: %__MODULE__{
+               first: Page.t,
+               last: Page.t,
+               next: Page.t,
+               previous: Page.t,
+               total_size: non_neg_integer
+             }
+
+  # Callbacks
+
+  @doc """
+  Converts the module's type to a `t` or `nil` if there is no pagination information.
+  """
+  @callback to_pagination(any) :: t | nil
+end

--- a/lib/alembic/pagination/page.ex
+++ b/lib/alembic/pagination/page.ex
@@ -1,0 +1,114 @@
+defmodule Alembic.Pagination.Page do
+  @moduledoc """
+  A page using paged pagination where the size of pages is fixed.
+  """
+
+  # Struct
+
+  defstruct number: 1,
+            size: 10
+
+  # Types
+
+  @typedoc """
+  * `number` - the 1-based page number
+  * `size` - the size of this page and all pages
+  """
+  @type t :: %__MODULE__{
+               number: non_neg_integer,
+               size: pos_integer
+             }
+
+  # Functions
+
+  @doc """
+  Extracts `number` from `query` `"page[number]"` and and `size` from `query` `"page[size]"`.
+
+      iex> Alembic.Pagination.Page.from_query("page%5Bnumber%5D=2&page%5Bsize%5D=10")
+      %Alembic.Pagination.Page{number: 2, size: 10}
+
+  If `query` does not have both `"page[number]"` and `"page[size]"` then `nil` is returned
+
+      iex> Alembic.Pagination.Page.from_query("page%5Bnumber%5D=2")
+      nil
+      iex> Alembic.Pagination.Page.from_query("page%5Bsize%5D=10")
+      nil
+      iex> Alembic.Pagination.Page.from_query("")
+      nil
+
+  """
+  @spec from_query(String.t) :: t
+  def from_query(query) when is_binary(query) do
+    reduced = query |>
+              URI.query_decoder
+              |> Enum.reduce(%__MODULE__{number: :unset, size: :unset}, &reduce_decoded_query_to_page/2)
+
+    case reduced do
+      %__MODULE__{number: number, size: size} when number == :unset or size == :unset ->
+        nil
+      set = %__MODULE__{} ->
+        set
+    end
+  end
+
+  @doc """
+  Extracts `number` from `uri` `query` `"page[number]"` and `size` from `uri` `query` `"page[size]"`.
+
+      iex> Alembic.Pagination.Page.from_uri(%URI{query: "page%5Bnumber%5D=2&page%5Bsize%5D=10"})
+      %Alembic.Pagination.Page{number: 2, size: 10}
+
+  If a `URI.t` `query` does not have both `"page[number]"` and `"page[size]"` then `nil` is returned
+
+      iex> Alembic.Pagination.Page.from_uri(%URI{query: "page%5Bnumber%5D=2"})
+      nil
+      iex> Alembic.Pagination.Page.from_uri(%URI{query: "page%5Bsize%5D=10"})
+      nil
+      iex> Alembic.Pagination.Page.from_uri(%URI{query: ""})
+      nil
+
+  If a `URI.t` does not have a query then `nil` is returned
+
+      iex> Alembic.Pagination.Page.from_uri(%URI{query: nil})
+      nil
+
+  """
+  @spec from_uri(URI.t) :: t | nil
+  def from_uri(uri)
+  def from_uri(%URI{query: nil}), do: nil
+  def from_uri(%URI{query: query}), do: from_query(query)
+
+  @doc """
+  Converts the `page` back to params.
+
+      iex> Alembic.Pagination.Page.to_params(%Alembic.Pagination.Page{number: 2, size: 10})
+      %{
+        "page" => %{
+          "number" => 2,
+          "size" => 10
+        }
+      }
+
+  """
+  @spec to_params(t) :: map
+  def to_params(page)
+  def to_params(%__MODULE__{number: number, size: size}) do
+    %{
+      "page" => %{
+        "number" => number,
+        "size" => size
+      }
+    }
+  end
+
+  ## Private Functions
+
+  defp reduce_decoded_query_to_page({"page[number]", encoded_page_number}, page = %__MODULE__{}) do
+    %__MODULE__{page | number: String.to_integer(encoded_page_number)}
+  end
+
+  defp reduce_decoded_query_to_page({"page[size]", encoded_page_size}, page = %__MODULE__{}) do
+    %__MODULE__{page | size: String.to_integer(encoded_page_size)}
+  end
+
+  defp reduce_decoded_query_to_page(_, page = %__MODULE__{}), do: page
+end

--- a/test/alembic/pagination/page_test.exs
+++ b/test/alembic/pagination/page_test.exs
@@ -1,0 +1,9 @@
+defmodule Alembic.Pagination.PageTest do
+  @moduledoc """
+  Runs doctests for `Alembic.Pagination.Page`
+  """
+
+  use ExUnit.Case, async: true
+
+  doctest Alembic.Pagination.Page
+end


### PR DESCRIPTION
# Changelog

## Enhancements
* `Pagination.Page` can store the `page[number]` and `page[size]` from a `URI`.
* `Link.to_page` can convert a URL to an `Pagination.Page`
* `Pagination` can store the `first`, `last`, `next`, and `previous` `Pagination.Page`s
* `Document.to_pagination` will extract the `first`, `last`, and `next`, and `previous` `Pagination.Page` from the `"first"`, `"last"`, `"next"`, and `"prev"` top-level `links`.  The `total_size` will be extracted from the top-level `meta` `"record_count"`.  This gives compatibility with the paged paginator in `JSONAPI::Resources` with `config.top_level_meta_include_record_count = true`.

## Incompatible Changes
* Make `Link.href_from_json` private as it should have alway been.
