### PR TITLE
Indirect relationships

### DIFF
--- a/lib/alembic/document.ex
+++ b/lib/alembic/document.ex
@@ -1724,7 +1724,7 @@ defmodule Alembic.Document do
   @spec to_params(t) :: [map] | map
   def to_params(document = %__MODULE__{}) do
     resource_by_id_by_type = included_resource_by_id_by_type(document)
-    to_params(document, resource_by_id_by_type)
+    to_params(document, resource_by_id_by_type, %{})
   end
 
   @doc """
@@ -1736,16 +1736,27 @@ defmodule Alembic.Document do
   """
   @spec to_params(%__MODULE__{data: [Resource.t] | Resource.t | nil},
                   ToParams.resource_by_id_by_type) :: ToParams.params
+  def to_params(document, resource_by_id_by_type), do: to_params(document, resource_by_id_by_type, %{})
 
-  def to_params(%__MODULE__{data: data}, resource_by_id_by_type) when is_list(data) do
-    Enum.map(data, &Resource.to_params(&1, resource_by_id_by_type))
+  @doc """
+  Transforms a `t` into the nested params format used by
+  [`Ecto.Changeset.cast/4`](http://hexdocs.pm/ecto/Ecto.Changeset.html#cast/4) using the given
+  `resources_by_id_by_type` and `converted_by_id_by_type`.
+
+  See `InterpreterServer.Api.Document.to_params/1`
+  """
+  @spec to_params(%__MODULE__{data: [Resource.t] | Resource.t | nil},
+                  ToParams.resource_by_id_by_type,
+                  ToParams.converted_by_id_by_type) :: ToParams.params
+  def to_params(%__MODULE__{data: data}, resource_by_id_by_type, converted_by_id_by_type) when is_list(data) do
+    Enum.map(data, &Resource.to_params(&1, resource_by_id_by_type, converted_by_id_by_type))
   end
 
-  def to_params(%__MODULE__{data: resource = %Resource{}}, resource_by_id_by_type) do
-    Resource.to_params(resource, resource_by_id_by_type)
+  def to_params(%__MODULE__{data: resource = %Resource{}}, resource_by_id_by_type, converted_by_id_by_type) do
+    Resource.to_params(resource, resource_by_id_by_type, converted_by_id_by_type)
   end
 
-  def to_params(%__MODULE__{data: nil}, _), do: %{}
+  def to_params(%__MODULE__{data: nil}, _, _), do: %{}
 
   ## Private functions
 

--- a/lib/alembic/fetch/includes.ex
+++ b/lib/alembic/fetch/includes.ex
@@ -105,9 +105,14 @@ defmodule Alembic.Fetch.Includes do
   @spec from_string(String.t) :: t
   def from_string(comma_separated_relationship_paths) do
     comma_separated_relationship_paths
-    |> String.splitter(",", trim: true)
+    |> String.splitter(relationship_path_separator, trim: true)
     |> Enum.map(&RelationshipPath.to_include/1)
   end
+
+  @doc """
+  Separates each relationship path in includes
+  """
+  def relationship_path_separator, do: ","
 
   @doc """
   Converts a String-based include that uses relationship names to Atom-based association names used in a preload
@@ -443,6 +448,16 @@ defmodule Alembic.Fetch.Includes do
   def to_relationship_path(include) do
     include
     |> to_relationship_path([])
+  end
+
+  @doc """
+  Converts a list of `include` back to a string
+  """
+  @spec to_string(includes :: [include]) :: String.t
+  def to_string(includes) when is_list(includes) do
+    includes
+    |> Stream.map(&to_relationship_path/1)
+    |> Enum.join(relationship_path_separator)
   end
 
   ## Private Functions

--- a/lib/alembic/relationship.ex
+++ b/lib/alembic/relationship.ex
@@ -17,11 +17,9 @@ defmodule Alembic.Relationship do
   alias Alembic.Links
   alias Alembic.Meta
   alias Alembic.ResourceLinkage
-  alias Alembic.ToEctoSchema
   alias Alembic.ToParams
 
   @behaviour FromJson
-  @behaviour ToEctoSchema
   @behaviour ToParams
 
   # Constants
@@ -382,163 +380,6 @@ defmodule Alembic.Relationship do
   end
 
   @doc """
-  Converts `t` to [`Ecto.Schema.t`](http://hexdocs.pm/ecto/Ecto.Schema.html#t:t/0) one or more structs.
-
-  ## To-one
-
-  An empty to-one, `nil`, is `nil` when converted because there is no type information.
-
-      iex> Alembic.Relationship.to_ecto_schema(
-      ...>   %Alembic.Relationship{data: nil},
-      ...>   %{},
-      ...>   %{}
-      ...> )
-      nil
-
-  A resource identifier uses `resource_by_id_by_type` to fill in the attributes of the referenced resource.
-
-      iex> Alembic.Relationship.to_ecto_schema(
-      ...>   %Alembic.Relationship{
-      ...>     data: %Alembic.ResourceIdentifier{
-      ...>       id: "1", type: "shirt"
-      ...>     }
-      ...>   },
-      ...>   %{
-      ...>     "shirt" => %{
-      ...>       "1" => %Alembic.Resource{
-      ...>         type: "shirt",
-      ...>         id: "1",
-      ...>         attributes: %{
-      ...>           "size" => "L"
-      ...>         }
-      ...>       }
-      ...>     }
-      ...>   },
-      ...>   %{
-      ...>     "shirt" => Alembic.TestShirt
-      ...>   }
-      ...> )
-      %Alembic.TestShirt{
-        __meta__: %Ecto.Schema.Metadata{
-          source: {nil, "shirts"},
-          state: :built
-        },
-        id: 1,
-        size: "L"
-      }
-
-  On create or update, a relationship can be created by having an `Alembic.Resource.t`, in which case the
-  attributes are supplied by the `Alembic.Resource.t`, instead of `resource_by_id_by_type`.
-
-      iex> Alembic.Relationship.to_ecto_schema(
-      ...>   %Alembic.Relationship{
-      ...>     data: %Alembic.Resource{
-      ...>       attributes: %{
-      ...>         "size" => "L"
-      ...>       },
-      ...>       type: "shirt"
-      ...>     }
-      ...>   },
-      ...>   %{},
-      ...>   %{
-      ...>     "shirt" => Alembic.TestShirt
-      ...>   }
-      ...> )
-      %Alembic.TestShirt{
-        __meta__: %Ecto.Schema.Metadata{
-          source: {nil, "shirts"},
-          state: :built
-        },
-        size: "L"
-      }
-
-  ## To-many
-
-  An empty to-many, `[]`, is `[]` when converted
-
-      iex> Alembic.Relationship.to_ecto_schema(
-      ...>   %Alembic.Relationship{
-      ...>     data: []
-      ...>   },
-      ...>   %{},
-      ...>   %{}
-      ...> )
-      []
-
-  A list of resource identifiers uses `resource_by_id_by_type` to fill in the attributes of the referenced resources.
-
-      iex> Alembic.Relationship.to_ecto_schema(
-      ...>   %Alembic.Relationship{
-      ...>     data: [
-      ...>       %Alembic.ResourceIdentifier{
-      ...>         id: "1", type: "shirt"
-      ...>       }
-      ...>     ]
-      ...>   },
-      ...>   %{
-      ...>     "shirt" => %{
-      ...>       "1" => %Alembic.Resource{
-      ...>         type: "shirt",
-      ...>         id: "1",
-      ...>         attributes: %{
-      ...>           "size" => "L"
-      ...>         }
-      ...>       }
-      ...>     }
-      ...>   },
-      ...>   %{
-      ...>     "shirt" => Alembic.TestShirt
-      ...>   }
-      ...> )
-      [
-        %Alembic.TestShirt{
-          __meta__: %Ecto.Schema.Metadata{
-            source: {nil, "shirts"},
-            state: :built
-          },
-          id: 1,
-          size: "L"
-        }
-      ]
-
-  On create or update, a relationship can be created by having an `Alembic.Resource.t`, in which case the
-  attributes are supplied by the `Alembic.Resource`, instead of `resource_by_id_by_type`.
-
-      iex> Alembic.Relationship.to_ecto_schema(
-      ...>   %Alembic.Relationship{
-      ...>     data: [
-      ...>       %Alembic.Resource{
-      ...>         attributes: %{
-      ...>           "size" => "L"
-      ...>         },
-      ...>         type: "shirt"
-      ...>       }
-      ...>     ]
-      ...>   },
-      ...>   %{},
-      ...>   %{
-      ...>     "shirt" => Alembic.TestShirt
-      ...>   }
-      ...> )
-      [
-        %Alembic.TestShirt{
-          __meta__: %Ecto.Schema.Metadata{
-            source: {nil, "shirts"},
-            state: :built
-          },
-          size: "L"
-        }
-      ]
-
-  """
-  @spec to_ecto_schema(%__MODULE__{data: nil},
-                       ToParams.resource_by_id_by_type,
-                       ToEctoSchema.ecto_schema_module_by_type) :: nil | [] | struct | [struct]
-  def to_ecto_schema(%__MODULE__{data: data}, resource_by_id_by_type, ecto_schema_module_by_type) do
-    ResourceLinkage.to_ecto_schema(data, resource_by_id_by_type, ecto_schema_module_by_type)
-  end
-
-  @doc """
   Converts `t` to params format used by [`Ecto.Changeset.cast/4`](http://hexdocs.pm/ecto/Ecto.Changeset.html#cast/4).
 
   ## To-one
@@ -655,7 +496,17 @@ defmodule Alembic.Relationship do
 
   """
   @spec to_params(%__MODULE__{data: any}, ToParams.resource_by_id_by_type) :: ToParams.params
-  def to_params(%__MODULE__{data: data}, resource_by_id_by_type) do
-    ResourceLinkage.to_params(data, resource_by_id_by_type)
+  def to_params(relationship, resource_by_id_by_type), do: to_params(relationship, resource_by_id_by_type, %{})
+
+  @doc """
+  Converts `t` to params format used by [`Ecto.Changeset.cast/4`](http://hexdocs.pm/ecto/Ecto.Changeset.html#cast/4),
+  but unlike `to_params/2`, will skip converting data in `t` where the `type` and `id` are already in
+  `converted_by_id_by_type`.
+  """
+  @spec to_params(%__MODULE__{data: any},
+                  ToParams.resource_by_id_by_type,
+                  ToParams.converted_by_id_by_type) :: ToParams.params
+  def to_params(%__MODULE__{data: data}, resource_by_id_by_type, converted_by_id_by_type) do
+    ResourceLinkage.to_params(data, resource_by_id_by_type, converted_by_id_by_type)
   end
 end

--- a/lib/alembic/relationships.ex
+++ b/lib/alembic/relationships.ex
@@ -16,11 +16,9 @@ defmodule Alembic.Relationships do
   alias Alembic.Error
   alias Alembic.FromJson
   alias Alembic.Relationship
-  alias Alembic.ToEctoSchema
   alias Alembic.ToParams
 
   @behaviour FromJson
-  @behaviour ToEctoSchema
   @behaviour ToParams
 
   # Constants
@@ -248,125 +246,6 @@ defmodule Alembic.Relationships do
   end
 
   @doc """
-  Converts relationships to map of the relationship's struct(s) that can be merged with the struct for the primary data
-
-  ## No relationships
-
-  No relationships are represented as `nil` in `IntrepreterServer.Api.Document.t`, but since the output of
-  `to_ecto_schema/2` is expected to be `struct/2` combinable with the primary resource's struct, an empty map is
-  returned when relationships is `nil`.
-
-      iex> Alembic.Relationships.to_ecto_schema(nil, %{}, %{})
-      %{}
-
-  ## Some Relationships
-
-  Relatonships are expected to be `struct/2` combinable with the primary resource's struct, so relationships are
-  returned as a map using the original relationship name and each `Alembic.Relationship.t` converted with
-  `Alembic.Relationship.to_ecto_schema/3`.
-
-  ### Resource Identifiers
-
-  If the resource linkage for a relationship is an `Alembic.ResourceIdentifier.t`, then the attributes for
-  the resource will be looked up in `resource_by_id_by_type`.
-
-      iex> Alembic.Relationships.to_ecto_schema(
-      ...>   %{
-      ...>     "author" => %Alembic.Relationship{
-      ...>       data: %Alembic.ResourceIdentifier{id: "1", type: "author"}
-      ...>     }
-      ...>   },
-      ...>   %{
-      ...>     "author" => %{
-      ...>       "1" => %Alembic.Resource{
-      ...>         type: "author",
-      ...>         id: "1",
-      ...>         attributes: %{
-      ...>           "name" => "Alice"
-      ...>         }
-      ...>       }
-      ...>     }
-      ...>   },
-      ...>   %{
-      ...>     "author" => Alembic.TestAuthor
-      ...>   }
-      ...> )
-      %{
-        "author" => %Alembic.TestAuthor{
-          __meta__: %Ecto.Schema.Metadata{
-            source: {nil, "authors"},
-            state: :built
-          },
-          id: 1,
-          name: "Alice"
-        }
-      }
-
-  Resources are not required to be in `resources_by_id_by_type`, as would be the case when only a foreign key is
-  supplied.
-
-      iex> Alembic.Relationships.to_ecto_schema(
-      ...>   %{
-      ...>     "author" => %Alembic.Relationship{
-      ...>       data: %Alembic.ResourceIdentifier{id: "1", type: "author"}
-      ...>     }
-      ...>   },
-      ...>   %{},
-      ...>   %{
-      ...>     "author" => Alembic.TestAuthor
-      ...>   }
-      ...> )
-      %{
-        "author" => %Alembic.TestAuthor{
-          __meta__: %Ecto.Schema.Metadata{
-            source: {nil, "authors"},
-            state: :built
-          },
-          id: 1
-        }
-      }
-
-  ### Resources
-
-  On create or update, the relationships can directly contain `Alembic.Resource.t` that are to be created,
-  in which case the `resource_by_id_by_type` are ignored.
-
-      iex> Alembic.Relationships.to_ecto_schema(
-      ...>   %{
-      ...>     "author" => %Alembic.Relationship{
-      ...>       data: %Alembic.Resource{
-      ...>         attributes: %{"name" => "Alice"},
-      ...>         type: "author"
-      ...>       }
-      ...>     },
-      ...>   },
-      ...>   %{},
-      ...>   %{
-      ...>     "author" => Alembic.TestAuthor
-      ...>   }
-      ...> )
-      %{
-        "author" => %Alembic.TestAuthor{
-          __meta__: %Ecto.Schema.Metadata{
-            source: {nil, "authors"},
-            state: :built
-          },
-          name: "Alice"
-        }
-      }
-  """
-
-  @spec to_ecto_schema(nil, ToParams.resource_by_id_by_type, ToEctoSchema.ecto_schema_module_by_type) :: map
-  def to_ecto_schema(nil, _, _), do: %{}
-
-  @spec to_ecto_schema(t, ToParams.resource_by_id_by_type, ToEctoSchema.ecto_schema_module_by_type) :: map
-  def to_ecto_schema(relationship_by_name, resource_by_id_by_type, ecto_schema_module_by_type) do
-    Enum.into relationship_by_name, %{}, fn {name, relationship} ->
-      {name, Relationship.to_ecto_schema(relationship, resource_by_id_by_type, ecto_schema_module_by_type)}
-    end
-  end
-
-  @doc """
   Converts relationships to params format used by
   [`Ecto.Changeset.cast/4`](http://hexdocs.pm/ecto/Ecto.Changeset.html#cast/4) that can be merged with the params
   from the primary data.
@@ -455,14 +334,19 @@ defmodule Alembic.Relationships do
         }
       }
   """
-
   @spec to_params(nil, ToParams.resource_by_id_by_type) :: %{}
-  def to_params(nil, _), do: %{}
-
   @spec to_params(t, ToParams.resource_by_id_by_type) :: ToParams.params
-  def to_params(relationship_by_name = %{}, resource_by_id_by_type = %{}) do
+  def to_params(relationship_by_name, resource_by_id_by_type) do
+    to_params(relationship_by_name, resource_by_id_by_type, %{})
+  end
+
+  @spec to_params(nil, ToParams.resource_by_id_by_type, ToParams.converted_by_id_by_type) :: %{}
+  def to_params(nil, _, _), do: %{}
+
+  @spec to_params(t, ToParams.resource_by_id_by_type, ToParams.converted_by_id_by_type) :: ToParams.params
+  def to_params(relationship_by_name = %{}, resource_by_id_by_type = %{}, converted_by_id_by_type) do
     Enum.into relationship_by_name, %{}, fn {name, relationship} ->
-      {name, Relationship.to_params(relationship, resource_by_id_by_type)}
+      {name, Relationship.to_params(relationship, resource_by_id_by_type, converted_by_id_by_type)}
     end
   end
 

--- a/lib/alembic/resource_linkage.ex
+++ b/lib/alembic/resource_linkage.ex
@@ -21,11 +21,9 @@ defmodule Alembic.ResourceLinkage do
   alias Alembic.FromJson
   alias Alembic.Resource
   alias Alembic.ResourceIdentifier
-  alias Alembic.ToEctoSchema
   alias Alembic.ToParams
 
   @behaviour FromJson
-  @behaviour ToEctoSchema
   @behaviour ToParams
 
   # Constants
@@ -347,170 +345,6 @@ defmodule Alembic.ResourceLinkage do
   def from_json(_, error_template), do: type_error(error_template)
 
   @doc """
-  Converts resource linkage to one or more [`Ecto.Schema.t`](http://hexdocs.pm/ecto/Ecto.Schema.html#t:t/0) structs.
-
-  ## To-one
-
-  An empty to-one, `nil`, is `nil` when converted to an Ecto Schema struct because no type information is available.
-
-      iex> Alembic.ResourceLinkage.to_ecto_schema(nil, %{}, %{})
-      nil
-
-  A resource identifier uses `resource_by_id_by_type` to fill in the attributes of the referenced resource. `type` is
-  dropped as [`Ecto.Changeset.cast/4`](http://hexdocs.pm/ecto/Ecto.Changeset.html#cast/4) doesn't verify types in the
-  params.
-
-      iex> Alembic.ResourceLinkage.to_ecto_schema(
-      ...>   %Alembic.ResourceIdentifier{
-      ...>     type: "shirt",
-      ...>     id: "1"
-      ...>   },
-      ...>   %{
-      ...>     "shirt" => %{
-      ...>       "1" => %Alembic.Resource{
-      ...>         type: "shirt",
-      ...>         id: "1",
-      ...>         attributes: %{
-      ...>           "size" => "L"
-      ...>         }
-      ...>       }
-      ...>     }
-      ...>   },
-      ...>   %{
-      ...>     "shirt" => Alembic.TestShirt
-      ...>   }
-      ...> )
-      %Alembic.TestShirt{
-        __meta__: %Ecto.Schema.Metadata{
-          source: {nil, "shirts"},
-          state: :built
-        },
-        id: 1,
-        size: "L"
-      }
-
-  On create or update, a relationship can be created by having an `Alembic.Resource.t`, in which case the
-  attributes are supplied by the `Alembic.Resource.t`, instead of `resource_by_id_by_type`.
-
-      iex> Alembic.ResourceLinkage.to_ecto_schema(
-      ...>   %Alembic.Resource{
-      ...>     attributes: %{
-      ...>       "size" => "L"
-      ...>     },
-      ...>     type: "shirt"
-      ...>   },
-      ...>   %{},
-      ...>   %{
-      ...>     "shirt" => Alembic.TestShirt
-      ...>   }
-      ...> )
-      %Alembic.TestShirt{
-        __meta__: %Ecto.Schema.Metadata{
-          source: {nil, "shirts"},
-          state: :built
-        },
-        size: "L"
-      }
-
-  ## To-many
-
-  An empty to-many, `[]`, is `[]` when converted because there is no type information available
-
-      iex> Alembic.ResourceLinkage.to_ecto_schema(
-      ...>   [],
-      ...>   %{},
-      ...>   %{}
-      ...> )
-      []
-
-  A list of resource identifiers uses `resources_by_id_by_type` to fill in the attributes of the referenced resources.
-
-      iex> Alembic.ResourceLinkage.to_ecto_schema(
-      ...>   [
-      ...>     %Alembic.ResourceIdentifier{
-      ...>       type: "shirt",
-      ...>       id: "1"
-      ...>     }
-      ...>   ],
-      ...>   %{
-      ...>     "shirt" => %{
-      ...>       "1" => %Alembic.Resource{
-      ...>         type: "shirt",
-      ...>         id: "1",
-      ...>         attributes: %{
-      ...>           "size" => "L"
-      ...>         }
-      ...>       }
-      ...>     }
-      ...>   },
-      ...>   %{
-      ...>     "shirt" => Alembic.TestShirt
-      ...>   }
-      ...> )
-      [
-        %Alembic.TestShirt{
-          __meta__: %Ecto.Schema.Metadata{
-            source: {nil, "shirts"},
-            state: :built
-          },
-          id: 1,
-          size: "L"
-        }
-      ]
-
-  On create or update, a relationship can be created by having an `Alembic.Resource`, in which case the
-  attributes are supplied by the `Alembic.Resource`, instead of `resource_by_id_by_type`.
-
-      iex> Alembic.ResourceLinkage.to_ecto_schema(
-      ...>   [
-      ...>     %Alembic.Resource{
-      ...>       attributes: %{
-      ...>         "size" => "L"
-      ...>       },
-      ...>       type: "shirt"
-      ...>     }
-      ...>   ],
-      ...>   %{},
-      ...>   %{
-      ...>     "shirt" => Alembic.TestShirt
-      ...>   }
-      ...> )
-      [
-        %Alembic.TestShirt{
-          __meta__: %Ecto.Schema.Metadata{
-            source: {nil, "shirts"},
-            state: :built
-          },
-          id: nil,
-          size: "L"
-        }
-      ]
-
-  """
-
-  @spec to_ecto_schema(nil, ToParams.resource_by_id_by_type, ToEctoSchema.ecto_schema_module_by_type) :: nil
-  def to_ecto_schema(nil, _, _), do: nil
-
-  @spec to_ecto_schema([Resource.t] | [ResourceIdentifier.t],
-                       ToParams.resource_by_id_by_type,
-                       ToEctoSchema.ecto_schema_module_by_type) :: [struct]
-  def to_ecto_schema(list, resource_by_id_by_type, ecto_schema_module_by_type) when is_list(list) do
-    Enum.map list, &to_ecto_schema(&1, resource_by_id_by_type, ecto_schema_module_by_type)
-  end
-
-  @spec to_ecto_schema(Resource.t | ResourceIdentifier.t,
-                       ToParams.resource_by_id_by_type,
-                       ToEctoSchema.ecto_schema_module_by_type) :: struct
-
-  def to_ecto_schema(resource_identifier = %ResourceIdentifier{}, resource_by_id_by_type, ecto_schema_module_by_type) do
-    ResourceIdentifier.to_ecto_schema(resource_identifier, resource_by_id_by_type, ecto_schema_module_by_type)
-  end
-
-  def to_ecto_schema(resource = %Resource{}, resource_by_id_by_type, ecto_schema_module_by_type) do
-    Resource.to_ecto_schema(resource, resource_by_id_by_type, ecto_schema_module_by_type)
-  end
-
-  @doc """
   Converts resource linkage to params format used by
   [`Ecto.Changeset.cast/4`](http://hexdocs.pm/ecto/Ecto.Changeset.html#cast/4).
 
@@ -623,19 +457,24 @@ defmodule Alembic.ResourceLinkage do
   """
   @spec to_params([Resource.t | ResourceIdentifier.t] | Resource.t | ResourceIdentifier.t | nil,
                   ToParams.resource_by_id_by_type) :: ToParams.params
+  def to_params(resource_linkage, resource_by_id_by_type), do: to_params(resource_linkage, resource_by_id_by_type, %{})
 
-  def to_params(nil, %{}), do: nil
+  @spec to_params([Resource.t | ResourceIdentifier.t] | Resource.t | ResourceIdentifier.t | nil,
+                  ToParams.resource_by_id_by_type,
+                  ToParams.converted_by_id_by_type) :: ToParams.params
 
-  def to_params(list, resource_by_id_by_type) when is_list(list) do
-    Enum.map list, &to_params(&1, resource_by_id_by_type)
+  def to_params(nil, %{}, %{}), do: nil
+
+  def to_params(list, resource_by_id_by_type, converted_by_id_by_type) when is_list(list) do
+    Enum.map list, &to_params(&1, resource_by_id_by_type, converted_by_id_by_type)
   end
 
-  def to_params(resource = %Resource{}, resource_by_id_by_type) do
-    Resource.to_params(resource, resource_by_id_by_type)
+  def to_params(resource = %Resource{}, resource_by_id_by_type, converted_by_id_by_type) do
+    Resource.to_params(resource, resource_by_id_by_type, converted_by_id_by_type)
   end
 
-  def to_params(resource_identifier = %ResourceIdentifier{}, resource_by_id_by_type) do
-    ResourceIdentifier.to_params(resource_identifier, resource_by_id_by_type)
+  def to_params(resource_identifier = %ResourceIdentifier{}, resource_by_id_by_type, converted_by_id_by_type) do
+    ResourceIdentifier.to_params(resource_identifier, resource_by_id_by_type, converted_by_id_by_type)
   end
 
   ## Private Functions

--- a/lib/alembic/to_ecto_schema.ex
+++ b/lib/alembic/to_ecto_schema.ex
@@ -28,6 +28,8 @@ defmodule Alembic.ToEctoSchema do
   """
   @type ecto_schema_module_by_type :: %{Resource.type => ecto_schema_module}
 
+  # Callbacks
+
   @doc """
   ## Parameters
 
@@ -46,17 +48,76 @@ defmodule Alembic.ToEctoSchema do
   """
   @callback to_ecto_schema(struct, ToParams.resource_by_id_by_type, ecto_schema_module_by_type) :: ecto_schema
 
+  # Functions
+
   @spec to_ecto_schema(ToParams.params, ecto_schema_module) :: struct
   # prefer to keep Ecto.Changeset instead of Changeset
   @lint {Credo.Check.Design.AliasUsage, false}
   def to_ecto_schema(params, ecto_schema_module) when is_atom(ecto_schema_module) do
     changeset = Ecto.Changeset.cast(ecto_schema_module.__struct__, params, ecto_schema_module.__schema__(:fields))
-    struct(ecto_schema_module, changeset.changes)
+
+    field_struct = struct(ecto_schema_module, changeset.changes)
+
+    :associations
+    |> ecto_schema_module.__schema__
+    |> Enum.reduce(field_struct, fn (association_name, acc) ->
+         put_named_association(acc, params, ecto_schema_module, association_name)
+       end)
   end
 
   @spec to_ecto_schema(%{type: Resource.type}, ToParams.params, ecto_schema_module_by_type) :: struct
   def to_ecto_schema(%{type: type}, params, ecto_schema_module_by_type) do
     ecto_schema_module = Map.fetch!(ecto_schema_module_by_type, type)
     to_ecto_schema(params, ecto_schema_module)
+  end
+
+  ## Private Functions
+
+  defp put_association(acc, relationship_params, %Ecto.Association.BelongsTo{field: field, owner_key: owner_key, related: related}) do
+    associated = case relationship_params do
+      map when is_map(map) -> to_ecto_schema(map, related)
+      nil -> nil
+    end
+
+    acc_with_associated = %{acc | field => associated}
+
+    case associated do
+      %{id: id} ->
+        %{acc_with_associated | owner_key => id}
+      _ ->
+        acc_with_associated
+    end
+  end
+
+  defp put_association(acc, relationship_params, %Ecto.Association.Has{cardinality: :many, field: field, related: related}) do
+    associated = case relationship_params do
+      list when is_list(list) ->
+        Enum.map(list, &to_ecto_schema(&1, related))
+      nil ->
+        nil
+    end
+
+    %{acc | field => associated}
+  end
+
+  defp put_association(acc, relationship_params, %Ecto.Association.Has{cardinality: :one, field: field, related: related}) do
+    associated = case relationship_params do
+      map when is_map(map) -> to_ecto_schema(map, related)
+      nil -> nil
+    end
+
+    %{acc | field => associated}
+  end
+
+  def put_named_association(acc, params, ecto_schema_module, association_name) do
+    relationship_name = to_string(association_name)
+
+    case Map.fetch(params, relationship_name) do
+      {:ok, relationship_params} ->
+        association = ecto_schema_module.__schema__(:association, association_name)
+        put_association(acc, relationship_params, association)
+      :error ->
+        acc
+    end
   end
 end


### PR DESCRIPTION
# Changelog
## Enhancements
* `ToEctoSchema.to_ecto_schema(params, module)` recursively converts nested params to the associated structs
* `Fetch.Includes.to_string` will take a list of includes and convert it back to the common-separated string format used by JSONAPI query parameters.

## Bug Fixes
* `to_params` and `to_ecto_schema` properly handles indirect relationships.

## Incompatible changes
* `ToParams` behaviour now requires `to_params/3` in addition to `to_params/2`
* Remove `to_ecto_schema/3` that are no longer called because of recursion in `ToEctoSchema.to_ecto_schema/2`
  * `Relationship`
  * `Relationships`
  * `ResourceIdentifier`
  * `ResourceLinkage`