### PR TITLE
Fix deprecation warnings for Ecto 1.1

### DIFF
--- a/lib/alembic/to_ecto_schema.ex
+++ b/lib/alembic/to_ecto_schema.ex
@@ -54,7 +54,7 @@ defmodule Alembic.ToEctoSchema do
   # prefer to keep Ecto.Changeset instead of Changeset
   @lint {Credo.Check.Design.AliasUsage, false}
   def to_ecto_schema(params, ecto_schema_module) when is_atom(ecto_schema_module) do
-    changeset = Ecto.Changeset.cast(ecto_schema_module.__struct__, params, ecto_schema_module.__schema__(:fields))
+    changeset = Ecto.Changeset.cast(ecto_schema_module.__struct__, params, [], ecto_schema_module.__schema__(:fields))
 
     field_struct = struct(ecto_schema_module, changeset.changes)
 

--- a/mix.exs
+++ b/mix.exs
@@ -50,7 +50,7 @@ defmodule Alembic.Mixfile do
       # markdown to HTML converter for ex_doc
       {:earmark, "~> 0.2.1", only: [:dev, :test]},
       # conversion to Ecto.Schema struct
-      {:ecto, "~> 1.0"},
+      {:ecto, "~> 1.1"},
       # documentation generation
       {:ex_doc, "~> 0.11.5", only: [:dev, :test]},
       # documentation coverage


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Use `Ecto.Changeset.cast/4` instead of `cast/3` to eliminate deprecation warning.