### PR TITLE
Represent no relationship data different than null data

### DIFF
--- a/lib/alembic/resource.ex
+++ b/lib/alembic/resource.ex
@@ -905,7 +905,7 @@ defmodule Alembic.Resource do
       }
 
   If the relationships does not have have an id (as may be the case where the server does not include linkage data
-  always), then the association will be be `nil` as will its foriegn key.
+  always), then the association will be `%Ecto.Association.NotLoaded{}` and its foriegn key will be `nil`.
 
       iex> Alembic.Resource.to_ecto_schema(
       ...>   %Alembic.Resource{
@@ -930,7 +930,11 @@ defmodule Alembic.Resource do
           source: {nil, "posts"},
           state: :built
         },
-        author: nil,
+        author: %Ecto.Association.NotLoaded{
+          __cardinality__: :one,
+          __field__: :author,
+          __owner__: Alembic.TestPost
+        },
         author_id: nil,
         text: "First!"
       }

--- a/lib/alembic/to_params.ex
+++ b/lib/alembic/to_params.ex
@@ -36,12 +36,18 @@ defmodule Alembic.ToParams do
 
   ## Returns
 
+  ### Success
+
   * `nil` if an empty singleton
   * `%{}` - if a non-empty singleton
   * `[]` - if an empty collection
   * `[%{}]` - if a non-empty collection
+
+  ### Errors
+
+  * `{:error, :unset}` - if the `convertable` data is not set
   """
-  @callback to_params(convertable :: any, resource_by_id_by_type) :: params
+  @callback to_params(convertable :: any, resource_by_id_by_type) :: params | {:error, :unset}
 
   @doc """
   Unlike `to_params/2`, if `type` and `id` of `convertable` already exists in `converted_by_id_by_type`, then the params
@@ -69,8 +75,11 @@ defmodule Alembic.ToParams do
   ### Errors
 
   * `{:error, :already_converted}` - if the `type` and `id` of `convertable` already exists in `converted_by_id_by_type`
+  * `{:error, :unset}` - if the `convertable` data is not set
   """
-  @callback to_params(convertable :: any, resource_by_id_by_type, converted_by_id_by_type) :: params
+  @callback to_params(convertable :: any,
+                      resource_by_id_by_type,
+                      converted_by_id_by_type) :: params | {:error, :already_converted | :unset}
 
   # Functions
 

--- a/test/poison/encoder/alembic/relationship_test.exs
+++ b/test/poison/encoder/alembic/relationship_test.exs
@@ -1,0 +1,8 @@
+defmodule Poison.Encoder.Alembic.RelationshipTest do
+  @moduledoc """
+  Runs doctests for `Poison.Encoder` implementation for `Alembic.Relationship`
+  """
+  use ExUnit.Case, async: true
+
+  doctest Poison.Encoder.Alembic.Relationship
+end


### PR DESCRIPTION
# Changelog
## Bug Fix
* Like `Document`, `Relationship` needs to differentiate between `"data":null` in the JSON and no data key at all, so have `Relationship.t` default to `:unset` instead of `nil`, the same way `Document.t` works now.  This means adding a `Poison.Encoder` implementation to not encode the `:unset` and changing the `ToParams` behaviour to allow for an `{:error, :unset}` return that the `Relationship.to_params` can return when `data` is `:unset`, so that `Relationships.to_params` will skip including the output in the map of all relationship params.