### PR TITLE
Documentation formatting

### DIFF
--- a/lib/alembic/document.ex
+++ b/lib/alembic/document.ex
@@ -358,141 +358,141 @@ defmodule Alembic.Document do
 
   A collection can be a list of resources
 
-     iex> Alembic.Document.from_json(
-     ...>   %{
-     ...>     "data" => [
-     ...>       %{
-     ...>         "attributes" => %{
-     ...>           "text" => "First Post!"
-     ...>         },
-     ...>         "id" => "1",
-     ...>         "relationships" => %{
-     ...>           "comments" => %{
-     ...>             "data" => [
-     ...>               %{
-     ...>                 "id" => "1",
-     ...>                 "type" => "comment"
-     ...>               }
-     ...>             ]
-     ...>           }
-     ...>         },
-     ...>         "type" => "post"
-     ...>       }
-     ...>     ]
-     ...>   },
-     ...>   %Alembic.Error{
-     ...>     meta: %{
-     ...>       "action" => :create,
-     ...>       "sender" => :client
-     ...>     },
-     ...>     source: %Alembic.Source{
-     ...>       pointer: ""
-     ...>     }
-     ...>   }
-     ...> )
-     {
-       :ok,
-       %Alembic.Document{
-         data: [
-           %Alembic.Resource{
-             attributes: %{
-               "text" => "First Post!"
-             },
-             id: "1",
-             relationships: %{
-               "comments" => %Alembic.Relationship{
-                 data: [
-                   %Alembic.ResourceIdentifier{
-                     id: "1",
-                     type: "comment"
-                   }
-                 ]
-               }
-             },
-             type: "post"
-           }
-         ]
-       }
-     }
+      iex> Alembic.Document.from_json(
+      ...>   %{
+      ...>     "data" => [
+      ...>       %{
+      ...>         "attributes" => %{
+      ...>           "text" => "First Post!"
+      ...>         },
+      ...>         "id" => "1",
+      ...>         "relationships" => %{
+      ...>           "comments" => %{
+      ...>             "data" => [
+      ...>               %{
+      ...>                 "id" => "1",
+      ...>                 "type" => "comment"
+      ...>               }
+      ...>             ]
+      ...>           }
+      ...>         },
+      ...>         "type" => "post"
+      ...>       }
+      ...>     ]
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: ""
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Alembic.Document{
+          data: [
+            %Alembic.Resource{
+              attributes: %{
+                "text" => "First Post!"
+              },
+              id: "1",
+              relationships: %{
+                "comments" => %Alembic.Relationship{
+                  data: [
+                    %Alembic.ResourceIdentifier{
+                      id: "1",
+                      type: "comment"
+                    }
+                  ]
+                }
+              },
+              type: "post"
+            }
+          ]
+        }
+      }
 
   With `"relationships"`, a resources collection can optionally have `"included"` for the attributes for the resource
   identifiers.  If `"included"` is not given or the `"id"` and `"type"` for a resource identifier, then the resource
   identifier should just be considered a foreign key reference that needs to be fetched with another API query.
 
-     iex> Alembic.Document.from_json(
-     ...>   %{
-     ...>     "data" => [
-     ...>       %{
-     ...>         "attributes" => %{
-     ...>           "text" => "First Post!"
-     ...>         },
-     ...>         "id" => "1",
-     ...>         "relationships" => %{
-     ...>           "comments" => %{
-     ...>             "data" => [
-     ...>               %{
-     ...>                 "id" => "1",
-     ...>                 "type" => "comment"
-     ...>               }
-     ...>             ]
-     ...>           }
-     ...>         },
-     ...>         "type" => "post"
-     ...>       }
-     ...>     ],
-     ...>     "included" => [
-     ...>       %{
-     ...>         "attributes" => %{
-     ...>           "text" => "First Comment!"
-     ...>         },
-     ...>         "id" => "1",
-     ...>         "type" => "comment"
-     ...>       }
-     ...>     ]
-     ...>   },
-     ...>   %Alembic.Error{
-     ...>     meta: %{
-     ...>       "action" => :create,
-     ...>       "sender" => :client
-     ...>     },
-     ...>     source: %Alembic.Source{
-     ...>       pointer: ""
-     ...>     }
-     ...>   }
-     ...> )
-     {
-       :ok,
-       %Alembic.Document{
-         data: [
-           %Alembic.Resource{
-             attributes: %{
-               "text" => "First Post!"
-             },
-             id: "1",
-             relationships: %{
-               "comments" => %Alembic.Relationship{
-                 data: [
-                   %Alembic.ResourceIdentifier{
-                     id: "1",
-                     type: "comment"
-                   }
-                 ]
-               }
-             },
-             type: "post"
-           }
-         ],
-         included: [
-           %Alembic.Resource{
-             attributes: %{
-               "text" => "First Comment!"
-             },
-             id: "1",
-             type: "comment"
-           }
-         ]
-       }
-     }
+      iex> Alembic.Document.from_json(
+      ...>   %{
+      ...>     "data" => [
+      ...>       %{
+      ...>         "attributes" => %{
+      ...>           "text" => "First Post!"
+      ...>         },
+      ...>         "id" => "1",
+      ...>         "relationships" => %{
+      ...>           "comments" => %{
+      ...>             "data" => [
+      ...>               %{
+      ...>                 "id" => "1",
+      ...>                 "type" => "comment"
+      ...>               }
+      ...>             ]
+      ...>           }
+      ...>         },
+      ...>         "type" => "post"
+      ...>       }
+      ...>     ],
+      ...>     "included" => [
+      ...>       %{
+      ...>         "attributes" => %{
+      ...>           "text" => "First Comment!"
+      ...>         },
+      ...>         "id" => "1",
+      ...>         "type" => "comment"
+      ...>       }
+      ...>     ]
+      ...>   },
+      ...>   %Alembic.Error{
+      ...>     meta: %{
+      ...>       "action" => :create,
+      ...>       "sender" => :client
+      ...>     },
+      ...>     source: %Alembic.Source{
+      ...>       pointer: ""
+      ...>     }
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Alembic.Document{
+          data: [
+            %Alembic.Resource{
+              attributes: %{
+                "text" => "First Post!"
+              },
+              id: "1",
+              relationships: %{
+                "comments" => %Alembic.Relationship{
+                  data: [
+                    %Alembic.ResourceIdentifier{
+                      id: "1",
+                      type: "comment"
+                    }
+                  ]
+                }
+              },
+              type: "post"
+            }
+          ],
+          included: [
+            %Alembic.Resource{
+              attributes: %{
+                "text" => "First Comment!"
+              },
+              id: "1",
+              type: "comment"
+            }
+          ]
+        }
+      }
 
   #### Resource Identifiers
 
@@ -680,7 +680,9 @@ defmodule Alembic.Document do
 
   ## Incomplete documents
 
-  If neither `"errors"`, `"data"`, nor `"meta"` is present, then the document is invalid and a `Alembic.
+  If neither `"errors"`, `"data"`, nor `"meta"` is present, then the document is invalid and an `:error` tuple will be
+  returned.  In the tuple with `:error` is an `Alembic.Document.t` that is a proper JSONAPI errors document that can
+  be set back to the sender.
 
       iex> Alembic.Document.from_json(
       ...>   %{},

--- a/lib/alembic/from_json.ex
+++ b/lib/alembic/from_json.ex
@@ -86,18 +86,20 @@ defmodule Alembic.FromJson do
 
   # Parameters
 
-  * `Alembic.json` - the decoded JSON from `Poison.decode/1` or some other JSON decoder.
-  * `%Alembic.Error{
-       meta: %{
-         "action" => Alembic.FromJson.action,
-         "sender" => Alembic.FromJson.sender
-       },
-       source: %Alembic.Source{
-                 parameter: nil,
-                 pointer: Alembic.json_pointer
-               }
-     }` - A prepolated error that includes a pointer for error repointing and meta information that influencing
-     validation.  For example, some formats are only accepted on `:create` or `:update` from the `:client`.
+  * `json` - the decoded JSON from `Poison.decode/1` or some other JSON decoder.
+  * `error_template` - A prepolated error that includes a pointer for error repointing and meta information that
+     influencing validation.  For example, some formats are only accepted on `:create` or `:update` from the `:client`.
+
+           %Alembic.Error{
+             meta: %{
+               "action" => Alembic.FromJson.action,
+               "sender" => Alembic.FromJson.sender
+             },
+             source: %Alembic.Source{
+               parameter: nil,
+               pointer: Alembic.json_pointer
+             }
+           }
 
   # Returns
 
@@ -111,7 +113,7 @@ defmodule Alembic.FromJson do
     `Alembic.Document.t`'s `errors`, as that `meta` information is an implementation detail and for
     internal use in recursive calls to `Alembic.FromJson.from_json/2` only.**
   """
-  @callback from_json(Alembic.json, Error.t) :: singleton_result
+  @callback from_json(decoded_json :: Alembic.json, error_template :: Error.t) :: singleton_result
 
   # Functions
 


### PR DESCRIPTION
# Changelog

## Bug Fixes
* Wrong number of spaces and missing closing backquotes led to some doctests not being rendered correctly.
* Fix docs for FromJson.from_json callback
  * Use `<name> :: <type>` format for parameters, so they don't appear as
`arg0` and `arg1` in the generated docs.
  * Use those names in the Paramaters section and code block teh format of
  the error template.