### PR TITLE
Convert nil nested params to nil foreign key

### DIFF
--- a/lib/alembic/to_params.ex
+++ b/lib/alembic/to_params.ex
@@ -102,6 +102,22 @@ defmodule Alembic.ToParams do
         "text" => "Welcome to my new blog!"
       }
 
+  `nil` for the nested parameters converts to a `nil` foreign key parameter
+
+      iex> Alembic.ToParams.nested_to_foreign_keys(
+      ...>   %{
+      ...>     "id" => 1,
+      ...>     "author" => nil,
+      ...>     "text" => "Welcome to my new blog!"
+      ...>   },
+      ...>   Alembic.TestPost
+      ...> )
+      %{
+        "id" => 1,
+        "author_id" => nil,
+        "text" => "Welcome to my new blog!"
+      }
+
   """
   @spec nested_to_foreign_keys(params, module) :: params
   def nested_to_foreign_keys(nested_params, schema_module) do

--- a/lib/alembic/to_params.ex
+++ b/lib/alembic/to_params.ex
@@ -118,6 +118,20 @@ defmodule Alembic.ToParams do
         "text" => "Welcome to my new blog!"
       }
 
+  This differs from when the nested parameters are not even present, in which case the foreign key won't be added
+
+      iex> Alembic.ToParams.nested_to_foreign_keys(
+      ...>   %{
+      ...>     "id" => 1,
+      ...>     "text" => "Welcome to my new blog!"
+      ...>   },
+      ...>   Alembic.TestPost
+      ...> )
+      %{
+        "id" => 1,
+        "text" => "Welcome to my new blog!"
+      }
+
   """
   @spec nested_to_foreign_keys(params, module) :: params
   def nested_to_foreign_keys(nested_params, schema_module) do

--- a/lib/alembic/to_params.ex
+++ b/lib/alembic/to_params.ex
@@ -132,6 +132,32 @@ defmodule Alembic.ToParams do
         "text" => "Welcome to my new blog!"
       }
 
+  From the other side of the `belongs_to`, the `has_many` nested params are unchanged
+
+      iex> Alembic.ToParams.nested_to_foreign_keys(
+      ...>   %{
+      ...>     "id" => 2,
+      ...>     "name" => "Alice",
+      ...>     "posts" => [
+      ...>       %{
+      ...>         "id" => 1,
+      ...>         "text" => "Welcome to my new blog!"
+      ...>       }
+      ...>     ]
+      ...>   },
+      ...>   Alembic.TestAuthor
+      ...> )
+      %{
+        "id" => 2,
+        "name" => "Alice",
+        "posts" => [
+          %{
+            "id" => 1,
+            "text" => "Welcome to my new blog!"
+          }
+        ]
+      }
+
   """
   @spec nested_to_foreign_keys(params, module) :: params
   def nested_to_foreign_keys(nested_params, schema_module) do


### PR DESCRIPTION
Fixes #27

# Changelog

## Enhancements
* Add more doctests to `Alembic.ToParams.nested_to_foreign_keys`
  * `nil` for the nested parameters converts to a `nil` foreign key parameter
  * When the nested parameters are not even present, the foreign key won't be added
  *` has_many` nested params are unchanged
## Bug Fixes
* Convert `nil` nested params to `nil` foreign key
