### PR TITLE
Elixir 1.3 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@
 
 # Changelog
 
+## v2.1.1
+
+### Bug Fixes
+* [#30](https://github.com/C-S-D/alembic/pull/30) - Elixir 1.3.0 compatibility - [KronicDeth](https://github.com/KronicDeth)
+  - Work-around [elixir-lang/elixir#4874)](https://github.com/elixir-lang/elixir/issues/4874) by aliasing `Alembic.Source` and using `Source.t` instead of `@for.t`.
+  - Use Erlang 18.3 instead of Erlang 19.0 until dialyer bug (http://bugs.erlang.org/browse/ERL-177) is fixed.
+
 ## v2.1.0
 
 ### Enhancements

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ dependencies:
     - sudo dpkg -i /home/ubuntu/erlang-solutions/erlang-solutions_1.0_all.deb
     - sudo apt-get update
     - sudo apt-get remove -y erlang-syntax-tools
-    - sudo apt-get install -y esl-erlang=1:19.0
+    - sudo apt-get install -y esl-erlang=1:18.3
     - sudo apt-get install -y elixir=1.3.0-1
     - mix local.hex --force && mix local.rebar --force
   post:

--- a/circle.yml
+++ b/circle.yml
@@ -12,9 +12,9 @@ dependencies:
     - if [[ ! -e ../erlang-solutions ]]; then cd .. && wget http://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && mkdir erlang-solutions && mv erlang-solutions_1.0_all.deb erlang-solutions && cd -; fi
     - sudo dpkg -i /home/ubuntu/erlang-solutions/erlang-solutions_1.0_all.deb
     - sudo apt-get update
-    - sudo apt-get install -y erlang erlang-ssl erlang-inets
-    - if [[ ! -e ../elixir ]]; then cd .. && git clone https://github.com/elixir-lang/elixir.git && cd elixir && git checkout v1.2.3 && make && cd /home/ubuntu; fi
-    - ln -s /home/ubuntu/elixir/bin/* /home/ubuntu/bin
+    - sudo apt-get remove -y erlang-syntax-tools
+    - sudo apt-get install -y esl-erlang=1:19.0
+    - sudo apt-get install -y elixir=1.3.0-1
     - mix local.hex --force && mix local.rebar --force
   post:
     - mix deps.get --only test

--- a/lib/alembic/source.ex
+++ b/lib/alembic/source.ex
@@ -235,6 +235,8 @@ defmodule Alembic.Source do
   end
 
   defimpl Poison.Encoder do
+    alias Alembic.Source
+
     @doc """
     Encoded `Alembic.Source.t` as a `String.t` contain a JSON object with either a `"parameter"` or `"pointer"` member.
     Whichever field is `nil` in the `Alembic.Source.t` does not appear in the output.
@@ -258,7 +260,8 @@ defmodule Alembic.Source do
         {:ok, "{\\"pointer\\":\\"/data\\"}"}
 
     """
-    @spec encode(@for.t, Keyword.t) :: String.t
+    # work-around https://github.com/elixir-lang/elixir/issues/4874
+    @spec encode(Source.t, Keyword.t) :: String.t
 
     def encode(%@for{parameter: parameter, pointer: nil}, options) when is_binary(parameter) do
       Poison.Encoder.Map.encode(%{"parameter" => parameter}, options)

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Alembic.Mixfile do
       source_url: "https://github.com/C-S-D/alembic",
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: Coverex.Task],
-      version: "2.1.0"
+      version: "2.1.1"
     ]
   end
 


### PR DESCRIPTION
# Changelog
## Bug Fixes
- Work-around [elixir-lang/elixir#4874)](https://github.com/elixir-lang/elixir/issues/4874) by aliasing `Alembic.Source` and using `Source.t` instead of `@for.t`.
- Use Erlang 18.3 instead of Erlang 19.0 until dialyer bug (http://bugs.erlang.org/browse/ERL-177) is fixed.
