### PR TITLE
Run credo on CodeClimate 

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,8 @@
+engines:
+  credo:
+    enabled: true
+    channel: beta
+ratings:
+  paths:
+  - "**.ex"
+  - "**.exs"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 # Alembic
 
 [![CircleCI](https://circleci.com/gh/C-S-D/alembic.svg?style=svg)](https://circleci.com/gh/C-S-D/alembic)
+[![Code Climate](https://codeclimate.com/github/C-S-D/alembic/badges/gpa.svg)](https://codeclimate.com/github/C-S-D/alembic)
 [![Deps Status](https://beta.hexfaktor.org/badge/all/github/C-S-D/alembic.svg)](https://beta.hexfaktor.org/github/C-S-D/alembic)
 [![Inline docs](http://inch-ci.org/github/C-S-D/alembic.svg)](http://inch-ci.org/github/C-S-D/alembic)
 

--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,6 @@ test:
   override:
     - mix test --cover
   post:
-    - mix credo --strict
     - mix dialyze
     - mix docs 2>&1 | tee mix-docs.txt
     - if grep "Closing unclosed backquotes" mix-docs.txt; then exit 1; fi


### PR DESCRIPTION
# Changelog
## Enhancements
* CodeClimate just added credo support to their beta engines channel.  Running on CodeClimate will allow the credo tests to run in parallel with CircleCI, leading to faster overall build times.