### PR TITLE
Sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@
 
 # Changelog
 
+## v3.1.0
+
+### Enhancements
+* [#40](https://github.com/C-S-D/alembic/pull/40) - `Alembic.Fetch.from_params`, in addition to parsing out the includes will not also parse out the sorts in the `"sort"` parameter using `Alembic.Fetch.Sorts.from_params`.  To transform the `Alembic.Fetch.Sorts.t` back to the string format in `"sort"`, you can use `Alembic.Fetch.Sorts.to_string/1`. - [KronicDeth](https://github.com/KronicDeth)
+
+### Bug Fixes
+* [#40](https://github.com/C-S-D/alembic/pull/40) - Change `:include` to `:includes` in the `@typedoc` for `Alembic.Fetch.t` - [KronicDeth](https://github.com/KronicDeth)
+
 ## v3.0.0
 
 ### Enhancements

--- a/lib/alembic/fetch.ex
+++ b/lib/alembic/fetch.ex
@@ -21,7 +21,7 @@ defmodule Alembic.Fetch do
   @typedoc """
   The options when performing a fetch
 
-  * `:include` - The relationships paths to include in the response document
+  * `:includes` - The relationships paths to include in the response document
   """
   @type t :: %__MODULE__{
                includes: nil | Includes.t

--- a/lib/alembic/fetch.ex
+++ b/lib/alembic/fetch.ex
@@ -4,12 +4,13 @@ defmodule Alembic.Fetch do
   """
 
   alias Alembic.Document
-  alias __MODULE__.Includes
+  alias __MODULE__.{Includes, Sorts}
   alias Ecto.Query
 
   # Struct
 
-  defstruct [:includes]
+  defstruct includes: [],
+            sorts: []
 
   # Types
 
@@ -22,9 +23,11 @@ defmodule Alembic.Fetch do
   The options when performing a fetch
 
   * `:includes` - The relationships paths to include in the response document
+  * `:sorts` - The attributes and their direction to sort in the response document.
   """
   @type t :: %__MODULE__{
-               includes: nil | Includes.t
+               includes: Includes.t,
+               sorts: Sorts.t
              }
 
   # Functions
@@ -59,11 +62,38 @@ defmodule Alembic.Fetch do
           ]
         }
 
+  `params` with `"sort"` will ahve the value of `"sort"` broken into `Alembic.Fetch.Sorts.t`
+
+        iex> Alembic.Fetch.from_params(
+        ...>   %{
+        ...>     "sort" => "author.name,-comments.author.posts.inserted-at"
+        ...>   }
+        ...> )
+        %Alembic.Fetch{
+          sorts: [
+            %Alembic.Fetch.Sort{
+              attribute: "name",
+              direction: :ascending,
+              relationship: "author"
+            },
+            %Alembic.Fetch.Sort{
+              attribute: "inserted-at",
+              direction: :descending,
+              relationship: %{
+                "comments" => %{
+                  "author" => "posts"
+                }
+              }
+            }
+          ]
+        }
+
   """
   @spec from_params(params) :: t
   def from_params(params) when is_map(params) do
     %__MODULE__{
-      includes: Includes.from_params(params)
+      includes: Includes.from_params(params),
+      sorts: Sorts.from_params(params)
     }
   end
 

--- a/lib/alembic/fetch/sort.ex
+++ b/lib/alembic/fetch/sort.ex
@@ -1,0 +1,145 @@
+defmodule Alembic.Fetch.Sort do
+  @moduledoc """
+  An individual sort in an `Alembic.Fetch.Sorts.t`
+  """
+
+  alias Alembic.Fetch.Includes
+
+  import Alembic.RelationshipPath, only: [reverse_relationship_names_to_include: 1]
+
+  # Struct
+
+  defstruct attribute: nil,
+            direction: :ascending,
+            relationship: nil
+
+  # Types
+
+  @typedoc """
+  The name of an attribute on the primary data or relationship to sort
+  """
+  @type attribute_name :: String.t
+
+  @typedoc """
+  The direction to sort.  Default to `:ascending` per the JSONAPI spec.  Can be `:descending` when the dot-separated
+  attribute path is prefixed with `-`.
+  """
+  @type direction :: :ascending | :descending
+
+  @typedoc """
+  * `:attribute` - the name of the attribute to sort
+  * `:direction` - the direction to sort `:attribute`.  Defaults to `:ascending`.  Can also be `:descending`.
+  * `:relationship` - the path to the relationship `:attribute` is on.  `nil` means the attribute is on the primary data
+  """
+  @type t :: %__MODULE__{
+               attribute: attribute_name,
+               direction: direction,
+               relationship: Includes.include | nil,
+             }
+
+  def related_attribute_path_separator, do: "."
+
+  @doc """
+  Breaks the (optionally prefixed) attribute path into a `t`.
+
+  A single attribute name will have the default direction of `:ascending` and no `:relationship`
+
+      iex> Alembic.Fetch.Sort.from_string("inserted-at")
+      %Alembic.Fetch.Sort{attribute: "inserted-at", direction: :ascending, relationship: nil}
+
+  An attribute name with `-` before it will have the direction reversed to `:descending`.
+
+      iex> Alembic.Fetch.Sort.from_string("-inserted-at")
+      %Alembic.Fetch.Sort{attribute: "inserted-at", direction: :descending, relationship: nil}
+
+  In a dot-separated sequence of names, the final name is the attribute name and all preceding names are a relationship
+  path in the same format as `Alembic.RelationshipPath`
+
+      iex> Alembic.Fetch.Sort.from_string("author.name")
+      %Alembic.Fetch.Sort{attribute: "name", direction: :ascending, relationship: "author"}
+      iex> Alembic.Fetch.Sort.from_string("comments.author.posts.inserted-at")
+      %Alembic.Fetch.Sort{
+        attribute: "inserted-at",
+        direction: :ascending,
+        relationship: %{
+          "comments" => %{
+            "author" => "posts"
+          }
+        }
+      }
+
+  """
+  @spec from_string(String.t) :: t
+  def from_string(string) when is_binary(string) do
+    {direction, related_attribute_path} = case string do
+      "-" <> descending_related_attribute_path -> {:descending, descending_related_attribute_path}
+      ascending_related_attribute_path -> {:ascending, ascending_related_attribute_path}
+    end
+
+    put_related_attribute_path(%__MODULE__{direction: direction}, related_attribute_path)
+  end
+
+  @doc """
+  Converts a sort back to the string format parsed by `from_string/1`
+
+  A `t` with `nil` relationship and the default direction of `:ascending` is only the `attribute`
+
+      iex> Alembic.Fetch.Sort.to_string(
+      ...>   %Alembic.Fetch.Sort{attribute: "inserted-at", relationship: nil}
+      ...> )
+      "inserted-at"
+
+  A `t` with direction of `:descending` will have a `"-"` prefix
+
+      iex> Alembic.Fetch.Sort.to_string(
+      ...>   %Alembic.Fetch.Sort{attribute: "inserted-at", direction: :descending, relationship: nil}
+      ...> )
+      "-inserted-at"
+
+  When there is a relationship, it is converted to a path in front of the attribute name, but after the direction prefix
+
+      iex> Alembic.Fetch.Sort.to_string(
+      ...>   %Alembic.Fetch.Sort{attribute: "inserted-at", direction: :descending, relationship: "comments"}
+      ...> )
+      "-comments.inserted-at"
+
+  Farther relationships are dot-separated
+
+      iex> Alembic.Fetch.Sort.to_string(
+      ...>   %Alembic.Fetch.Sort{
+      ...>     attribute: "inserted-at",
+      ...>     direction: :descending,
+      ...>     relationship: %{
+      ...>       "comments" => %{
+      ...>         "author" => "posts"
+      ...>       }
+      ...>     }
+      ...>   }
+      ...> )
+      "-comments.author.posts.inserted-at"
+
+  """
+  @spec to_string(t) :: String.t
+  def to_string(sort), do: prefix(sort) <> related_attribute_path(sort)
+
+  ## Private Functions
+
+  defp prefix(%__MODULE__{direction: :ascending}), do: ""
+  defp prefix(%__MODULE__{direction: :descending}), do: "-"
+
+  # Break up `related_attribute_path` into `relationship` and `attribute` components and puts them into `sort`
+  defp put_related_attribute_path(sort = %__MODULE__{}, related_attribute_path) do
+    [attribute_name | reverse_relationship_names] = related_attribute_path
+                                                   |> String.split(related_attribute_path_separator())
+                                                   |> Enum.reverse()
+
+    relationship = reverse_relationship_names_to_include(reverse_relationship_names)
+
+    %__MODULE__{sort | attribute: attribute_name, relationship: relationship}
+  end
+
+  defp related_attribute_path(%__MODULE__{attribute: attribute, relationship: nil}), do: attribute
+  defp related_attribute_path(%__MODULE__{attribute: attribute, relationship: relationship}) do
+    Includes.to_relationship_path(relationship) <> related_attribute_path_separator() <> attribute
+  end
+end

--- a/lib/alembic/fetch/sorts.ex
+++ b/lib/alembic/fetch/sorts.ex
@@ -1,0 +1,115 @@
+defmodule Alembic.Fetch.Sorts do
+  @moduledoc """
+  [Fetching Data > Sorting](http://jsonapi.org/format/#fetching-sorting)
+  """
+
+  alias Alembic.Fetch.Sort
+
+  # Types
+
+  @type params :: %{}
+
+  @typedoc """
+  An order `list` of `Alembic.Fetch.Sort.t`
+  """
+  @type t :: [Sort.t]
+
+  # Functions
+
+  @doc """
+  Extracts `t` from `"sort"` in `params`
+
+  `params` without `"sort"` will have no sorts
+
+      iex> Alembic.Fetch.Sorts.from_params(%{})
+      []
+
+  `params` with `"sort"` will have the value of `"sort"` broken into `t`
+
+      iex> Alembic.Fetch.Sorts.from_params(
+      ...>   %{
+      ...>     "sort" => "-inserted-at,author.name,-comments.author.posts.inserted-at"
+      ...>   }
+      ...> )
+      [
+        %Alembic.Fetch.Sort{attribute: "inserted-at", direction: :descending, relationship: nil},
+        %Alembic.Fetch.Sort{attribute: "name", direction: :ascending, relationship: "author"},
+        %Alembic.Fetch.Sort{
+          attribute: "inserted-at",
+          direction: :descending,
+          relationship: %{
+            "comments" => %{
+              "author" => "posts"
+            }
+          }
+        }
+      ]
+
+  """
+  @spec from_params(params) :: t
+  def from_params(params) when is_map(params) do
+    case Map.fetch(params, "sort") do
+      :error ->
+        []
+      {:ok, sort} ->
+        from_string(sort)
+    end
+  end
+
+  @doc """
+  Breaks the `sort` into list of `Alembic.Fetch.Sort.t`
+
+  An empty String will have no sorts
+
+      iex> Alembic.Fetch.Sorts.from_string("")
+      []
+
+  A single attribute name will have the default direction of `:ascending` and no `:relationship`
+
+      iex> Alembic.Fetch.Sorts.from_string("inserted-at")
+      [%Alembic.Fetch.Sort{attribute: "inserted-at", direction: :ascending, relationship: nil}]
+
+  An attribute name with `-` before will have the direction reversed to `:descending`.
+
+      iex> Alembic.Fetch.Sorts.from_string("-inserted-at")
+      [%Alembic.Fetch.Sort{attribute: "inserted-at", direction: :descending, relationship: nil}]
+
+  In a dot-seperated sequence of names, the final name is the attribute name and all preceding names are a relationship
+  path in the same format as `Alembic.RelationshipPath`
+
+      iex> Alembic.Fetch.Sorts.from_string("author.name,-comments.author.posts.inserted-at")
+      [
+        %Alembic.Fetch.Sort{attribute: "name", direction: :ascending, relationship: "author"},
+        %Alembic.Fetch.Sort{
+          attribute: "inserted-at",
+          direction: :descending,
+          relationship: %{
+            "comments" => %{
+              "author" => "posts"
+            }
+          }
+        }
+      ]
+  """
+  @spec from_string(String.t) :: t
+  def from_string(comma_seperated_sorts) do
+    comma_seperated_sorts
+    |> String.splitter(sort_separator(), trim: true)
+    |> Enum.map(&Sort.from_string/1)
+  end
+
+  @doc """
+  Separates each sort in `"sort"`
+  """
+  def sort_separator, do: ","
+
+  @doc """
+  Converts a list of `Alembic.Fetch.Sort.t` back to a string
+  """
+  @spec to_string(t) :: String.t
+  def to_string(sorts) when is_list(sorts) do
+    sorts
+    |> Stream.map(&Sort.to_string/1)
+    |> Enum.join(sort_separator())
+  end
+end

--- a/lib/alembic/relationship_path.ex
+++ b/lib/alembic/relationship_path.ex
@@ -31,6 +31,18 @@ defmodule Alembic.RelationshipPath do
   """
   def relationship_name_separator, do: "."
 
+  @doc false
+
+  @spec reverse_relationship_names_to_include([]) :: nil
+  def reverse_relationship_names_to_include([]), do: nil
+
+  @spec reverse_relationship_names_to_include([relationship_name, ...]) :: Includes.include
+  def reverse_relationship_names_to_include(reverse_relationship_names) do
+    Enum.reduce reverse_relationship_names, fn (relationship_name, include) ->
+      %{relationship_name => include}
+    end
+  end
+
   @doc """
   Breaks the `relationship_path` into `relationship_name`s in a nested map to form
   `Alembic.Fetch.Include.include`
@@ -50,13 +62,11 @@ defmodule Alembic.RelationshipPath do
       }
 
   """
-  @spec to_include(t) :: Includes.include
+  @spec to_include(t) :: Includes.include | nil
   def to_include(relationship_path) do
     relationship_path
     |> String.split(relationship_name_separator)
     |> Enum.reverse
-    |> Enum.reduce(fn (relationship_name, include) ->
-         %{relationship_name => include}
-       end)
+    |> reverse_relationship_names_to_include()
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Alembic.Mixfile do
       source_url: "https://github.com/C-S-D/alembic",
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: Coverex.Task],
-      version: "3.0.0"
+      version: "3.1.0"
     ]
   end
 

--- a/test/alembic/fetch/sort_test.exs
+++ b/test/alembic/fetch/sort_test.exs
@@ -1,0 +1,9 @@
+defmodule Alembic.Fetch.SortTest do
+  @moduledoc """
+  Runs doctests for `Alembic.Fetch.Sort`
+  """
+
+  use ExUnit.Case, async: true
+
+  doctest Alembic.Fetch.Sort
+end

--- a/test/alembic/fetch/sorts_test.exs
+++ b/test/alembic/fetch/sorts_test.exs
@@ -1,0 +1,9 @@
+defmodule Alembic.Fetch.SortsTest do
+  @moduledoc """
+  Runs doctests for `Alembic.Fetch.Sorts`
+  """
+
+  use ExUnit.Case, async: true
+
+  doctest Alembic.Fetch.Sorts
+end

--- a/test/support/api/test_post.ex
+++ b/test/support/api/test_post.ex
@@ -8,6 +8,8 @@ defmodule Alembic.TestPost do
   schema "posts" do
     field :text, :string
 
+    timestamps
+
     belongs_to :author, Alembic.TestAuthor
     has_many :comments, Alembic.TestComment
   end


### PR DESCRIPTION
Fixes #35 

# Changelog
## Enhancements
* `Alembic.Fetch.from_params`, in addition to parsing out the includes will not also parse out the sorts in the `"sort"` parameter using `Alembic.Fetch.Sorts.from_params`.  To transform the `Alembic.Fetch.Sorts.t` back to the string format in `"sort"`, you can use `Alembic.Fetch.Sorts.to_string/1`.

## Bug Fixes
* Change `:include` to `:includes` in the `@typedoc` for `Alembic.Fetch.t`
