### PR TITLE
Allow Alembic.Error source to be nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@
 
 # Changelog
 
+## v3.2.1
+
+### Bug Fixes
+* [#43](https://github.com/C-S-D/alembic/pull/43) - [@KronicDeth](https://github.com/KronicDeth)
+  * Allow `Alembic.Error.t` `source` to be `nil`
+  * Lower minimum coverage because coverage number varies from run to run.
+
 ## v3.2.0
 
 ### Enhancements

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,5 +1,5 @@
 {
   "coverage_options": {
-    "minimum_coverage": 94.677
+    "minimum_coverage": 93.916
   }
 }

--- a/lib/alembic/error.ex
+++ b/lib/alembic/error.ex
@@ -128,7 +128,7 @@ defmodule Alembic.Error do
                id: String.t | nil,
                links: Links.t | nil,
                meta: %{String.t => Alembic.json | atom} | nil,
-               source: Source.t,
+               source: Source.t | nil,
                status: String.t | nil,
                title: String.t | nil
              }

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule Alembic.Mixfile do
       source_url: "https://github.com/C-S-D/alembic",
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: ExCoveralls],
-      version: "3.2.0"
+      version: "3.2.1"
     ]
   end
 


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Allow `Alembic.Error.t` `source` to be `nil`
* Lower minimum coverage because coverage number varies from run to run.