### PR TITLE
Remove Api references

### DIFF
--- a/lib/alembic/document.ex
+++ b/lib/alembic/document.ex
@@ -1861,7 +1861,7 @@ defmodule Alembic.Document do
   [`Ecto.Changeset.cast/4`](http://hexdocs.pm/ecto/Ecto.Changeset.html#cast/4) using the given
   `resources_by_id_by_type` and `converted_by_id_by_type`.
 
-  See `InterpreterServer.Api.Document.to_params/1`
+  See `Alembic.Document.to_params/1`
   """
   @spec to_params(
           %__MODULE__{data: [Resource.t] | Resource.t | nil},

--- a/lib/alembic/source.ex
+++ b/lib/alembic/source.ex
@@ -36,7 +36,7 @@ defmodule Alembic.Source do
   @typedoc """
   A pointer path is composed of the `parent` pointer and the final `child` name.
   """
-  @type pointer_path :: {parent :: Api.json_pointer, child :: String.t}
+  @type pointer_path :: {parent :: Alembic.json_pointer, child :: String.t}
 
   @typedoc """
   An object containing references to the source of the [error](http://jsonapi.org/format/#error-objects), optionally
@@ -53,7 +53,7 @@ defmodule Alembic.Source do
              |
              %__MODULE__{
                parameter: nil,
-               pointer: Api.json_pointer
+               pointer: Alembic.json_pointer
              }
 
   @doc """


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Remove references to `(InterpreterServer.)Api` that were leftover from when `Alembic` was open-sourced and extracted from `interpreter-server`.
  * Replace references to `Api.json_pointer` with `Alembic.json_pointer` as they couldn't be resolved and triggered an `Unknown Type: Elixir.Api.json_pointer` when dialyzer is used in dependent projects.